### PR TITLE
Arcolinux, fancy installer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,16 @@ Just apply the "desktop tweaks" for the environment, don't do the full install.
 
 Removes the "desktop tweaks" the installer applied.  
 
+And finally:  
+
+```sh
+./toshy_setup.py --fancy-pants
+```
+
+This will do the full install, but add various things that I find convenient, fun, or somehow makes the desktop environment more Mac-like.  
+
+At the moment this just installs a monospace font that I find enjoyable to use in terminals and some code editors (Fantasque Sans Mono, but from a GitHub fork with coding ligatures removed), and in KDE it will install a KWin script that allows task switching with `Cmd+Tab` to bring all windows of the same application to the front together, as a group (like macOS, or like GNOME's "Switch applications").  
+
 ## Currently working/tested Linux distros:
 
 What I've been able to test so far:  

--- a/README.md
+++ b/README.md
@@ -106,22 +106,25 @@ There's no simple way around this, since the keymapper is only designed to send 
 
     - Wayland+GNOME requires one of these GNOME Shell extensions‡ (see note):
 
-        - Focused Window D-Bus
-        - https://extensions.gnome.org/extension/5592/focused-window-d-bus/
+        - ### Name: 'Xremap' (try this if you have an older GNOME version)
+        - UUID: `xremap@k0kubun.com`
+        - URL: https://extensions.gnome.org/extension/5060/xremap/
 
-        - Window Calls Extended
-        - https://extensions.gnome.org/extension/4974/window-calls-extended/
+        - ### Name: 'Window Calls Extended'
+        - UUID: `window-calls-extended@hseliger.eu`
+        - URL: https://extensions.gnome.org/extension/4974/window-calls-extended/
 
-        - Xremap (try this if you have an older GNOME version)
-        - https://extensions.gnome.org/extension/5060/xremap/
+        - ### Name: 'Focused Window D-Bus'
+        - UUID: `focused-window-dbus@flexagoon.com`
+        - URL: https://extensions.gnome.org/extension/5592/focused-window-d-bus/
 
     - Wayland+KDE has a small glitch where you have to change the focused window once after the KWin script it installed, to get the app-specific remapping to start working. 
 
-- `systemd` (but you can just manually run the config from terminal, or shell script, or tray indicator menu)
+- `systemd` (but you can just manually run the config from terminal, shell script, or tray indicator menu)
 
 - D-Bus, and `dbus-python` (for the tray indicator and GUI app)
 
-‡ Note: It's very easy to search for and install GNOME Shell extensions now, if you install the "Extension Manager" Flatpak application from Flathub. No need to mess around with downloading a zip file from `extensions.gnome.org` and manually installing/enabling in the terminal. Many distros with GNOME need the `AppIndicator & KStatusNotifier` extension to make the tray icon appear in the top bar, and if you want to use Wayland you'll need one of the extensions from the list above.  
+‡ Note: It's very easy to search for and install GNOME Shell extensions now, if you install the "Extension Manager" Flatpak application from Flathub. No need to mess around with downloading a zip file from `extensions.gnome.org` and manually installing/enabling in the terminal. Many distros with GNOME need the `AppIndicator and KStatusNotifier` extension to make the tray icon appear in the top bar, and if you want to use Wayland you'll need one of the extensions from the list above.  
 
 ```sh
 flatpak install com.mattjakeman.ExtensionManager
@@ -149,11 +152,53 @@ The `Xremap` GNOME shell extension is the only one that supports older GNOME ver
 ./toshy_setup.py
 ```
 
-## Currently tested/working Linux distros:
+### Options for installer
+
+The installer has a couple of options available:  
+
+```sh
+./toshy_setup.py --show-env
+```
+
+This will just show what the installer will see as the environment when you try to install, but won't actually run the full install process.  
+
+```sh
+./toshy_setup.py --list-distros
+```
+
+This will print out a list of the distros that the Toshy installer theoretically "knows" how to deal with, as far as knowing the correct package manager to use and having a list of package names that would actually work. This can be used with:  
+
+```sh
+./toshy_setup.py --override-distro=distroname
+```
+
+This option will force the installer to attempt the install for that distro name/type. You can use this if you have a distro that is not on the distro list yet, but you think it is close enough to one of the existing distros in the list that the installer should do the right things. For instance if you have some very Arch-ish or very Debian-ish distro, or something based on Ubuntu (there are many!) that doesn't identify as one of the "known" distros when you use `--show-env` and `--list-distros`, then you can try to make it install using one of the related distro names. This will probably work, if the distro is just a minor variation of its parent distro.  
+
+You don't have to run any of these commands before trying the installer, it will let you know almost immediately if it doesn't know how to install on your distro.  
+
+Other options for the installer:  
+
+```sh
+./toshy_setup.py --apply-tweaks
+```
+
+Just apply the "desktop tweaks" for the environment, don't do the full install.  
+
+```sh
+./toshy_setup.py --remove-tweaks
+```
+
+Removes the "desktop tweaks" the installer applied.  
+
+## Currently working/tested Linux distros:
+
+What I've been able to test so far:  
+
+### Red Hat and similar distros
 
 - Fedora 36/[37*]/38 (from Red Hat)
 
-    - Standard GNOME variant tested
+    - Standard GNOME variant tested (Wayland session requires extensions)
     - KDE variant tested (X11/Xorg or Wayland+KDE session)
     - Fedora 37 not directly tested, but should work since F36/F38 work
 
@@ -161,25 +206,28 @@ The `Xremap` GNOME shell extension is the only one that supports older GNOME ver
 
     - Tested with "Workstation" installer choice, not "Server with GUI"
     - Some non-default (but official) repos will be enabled
-    - NB: There is no journal output for "user" services, for some reason
+    - NB: There is no journal for "user" services, for some reason
 
-- Other RHEL clones should be supportable **_(just need distro name added to installer)_**
+- Other RHEL clones should be supportable
 
     - EuroLinux? Probably.
     - Red Hat Enterprise Linux itself? Probably.
+    - Try `./toshy_setup.py --override-distro=almalinux`
 
-- Linux Mint 21.1 (Ubuntu-based)
+### openSUSE (RPM-based packaging system)
 
-    - Cinnamon desktop
-    - Xfce desktop
-    - MATE desktop
-    - All desktops can be installed on the same Mint system:
+- openSUSE Tumbleweed (rolling release)
 
-```sh
-sudo apt install mint-meta-mate mint-meta-xfce mint-meta-cinnamon
-```
+    - GNOME desktop works (Wayland session needs shell extensions, see Requirements)
+    - KDE desktop works (X11/Xorg or Wayland)
+    - Other desktop choices should work, if session is X11/Xorg
 
-- LMDE 5 (Linux Mint Debian Edition)
+- openSUSE Leap is currently UNSUPPORTED
+
+    - Leap still comes with Python version 3.6.x
+    - Current Python version on most distros is 3.9/3.10/3.11
+
+### Ubuntu variants and Ubuntu-based distros
 
 - Ubuntu official variants tested:
 
@@ -202,50 +250,70 @@ sudo apt install mint-meta-mate mint-meta-xfce mint-meta-cinnamon
 
 - elementary OS 7.0 (Ubuntu-based)
 
-- Manjaro (Arch-based)
+- Linux Mint 21.1 (Ubuntu-based)
 
-    - NOTE: Manjaro only seems to use X11/Xorg for now
-    - GNOME desktop variant tested
-    - Xfce desktop variant tested
-    - KDE Plasma desktop variant tested (see FAQ Re: Application Menu shortcut)
+    - Cinnamon desktop
+    - Xfce desktop
+    - MATE desktop
+    - All desktops can be installed on the same Mint system:
+    - `sudo apt install mint-meta-mate mint-meta-xfce mint-meta-cinnamon`
+
+### Debian and Debian-based distros
+
+- LMDE 5 (Linux Mint Debian Edition)
+
+- antiX (Debian-based, related to MX Linux)
+
+    - Preliminary support, no SysVinit services yet, so no auto-start.
+    - Starting only the "config script" from the tray icon menu should work now.
+    - Use `toshy-config-start` or `toshy-config-start-verbose` for manual start.
+    - Only "rox-icewm" desktop verified/tested.
+
+- MX Linux (Debian-based, related to antiX)
+
+    - Preliminary support, no SysVinit services yet, so no auto-start.
+    - Starting only the "config script" from the tray icon menu should work now.
+    - Use `toshy-config-start` or `toshy-config-start-verbose` for manual start.
+    - Choosing advanced options and booting with `systemd` will work fine.
+
+- Debian distros in general might work, because:
+
+    - antiX & MX Linux are based on Debian 11 Bullseye and identify as `debian`.
+
+### Arch, Arch-based and related distros
+
+- Arcolinux (Arch-based)
+
+    - ArcolinuxL ISO (full installer) tested
+    - Multiple desktops tested (GNOME, KDE, others)
+    - X11/Xorg and Wayland+KDE, Wayland+GNOME
+    - `plasma-wayland-session` can be installed
+    - See FAQ Re: Application Menu shortcut fix
+    - NB: No journal for "user" systemd services, for some reason
 
 - EndeavourOS (Arch-based)
 
     - Most desktops should work in X11/Xorg
     - GNOME desktop should work in X11/Xorg and Wayland (requires extension)
     - KDE (Plasma) desktop should work in X11/Xorg and Wayland
+    - `plasma-wayland-session` can be installed
+
+- Manjaro (Arch-based)
+
+    - GNOME desktop variant tested
+    - Xfce desktop variant tested
+    - KDE Plasma desktop variant tested
+    - `plasma-wayland-session` can be installed
+    - See FAQ Re: Application Menu shortcut fix
 
 - Arch in general? (maybe, needs more testing)
 
     - Installer will try to work on any distro that identifies as `Arch`
 
-- antiX (Debian-based, related to MX Linux)
-
-    - Preliminary support, no SysVinit services yet, so no auto-start.
-    - Use `toshy-config-start` or `toshy-config-start-verbose` for manual start.
-    - Starting only the "config script" from the tray icon menu should work now.
-    - Only "rox-icewm" desktop verified/tested.
-
-- MX Linux (Debian-based, related to antiX)
-
-    - Preliminary support, no SysVinit services yet, so no auto-start.
-    - Use `toshy-config-start` or `toshy-config-start-verbose` for manual start.
-    - Starting only the "config script" from the tray icon menu should work now.
-    - Choosing advanced options and booting with `systemd` will work fine.
-
-- Debian in general might work, because:
-
-    - antiX & MX Linux are based on Debian 11 Bullseye and identify as `debian`.
-
-- openSUSE Tumbleweed (rolling release)
-
-    - GNOME desktop works (Wayland session needs shell extensions, see Requirements)
-    - KDE desktop works (X11/Xorg or Wayland)
-
 ## Currently working desktop environments / window managers
 
-- X11/Xorg (all desktops)
-- Wayland+GNOME
+- X11/Xorg (all desktop environments)
+- Wayland+GNOME (needs shell extension)
 - Wayland+KDE (change window focus once to make it work)
 
 If you are in an X11/Xorg login session, the desktop environment or window manager doesn't really matter. The keymapper gets the window class/name/title information directly from the X server with `Xlib`.  
@@ -610,9 +678,9 @@ qdbus org.kde.KWin /KWin reconfigure
 
 To undo this, remove or comment out the same text in the file, and run the same command. The `Meta` key binding should be back.  
 
-### Manjaro KDE shortcut for Application Menu
+### Manjaro/Arcolinux KDE shortcut for Application Menu
 
-Something strange is happening in Manjaro KDE with the shortcut to open the application menu/launcher applet. In the primary shortcut settings control panel, there is a shortcut of `Alt+F1` set, which should work with the Toshy config. But the `Alt+F1` shortcut doesn't even work with Toshy disabled. If you right-click on the menu icon you can open the applet settings dialog and set the `Alt+F1` shortcut in its preferences (choose to reassign it) and then hit Apply, and it will start working with `Cmd+Space` when Toshy is enabled. And also it will now work even when Toshy is disabled. There are other identically named shortcut settings in the main KDE control panel for shortcuts, but they seem to want to open `krunner`, the search/launcher bar that pops out from the top of the screen.  
+Something strange is happening in Manjaro KDE and Arcolinux KDE desktops with the shortcut to open the application menu/launcher applet. In the primary shortcut settings control panel, there is a shortcut of `Alt+F1` set, which should work with the Toshy config. But the `Alt+F1` shortcut doesn't even work with Toshy disabled. If you right-click on the menu icon you can open the applet settings dialog and set the `Alt+F1` shortcut in its preferences (choose to reassign it) and then hit Apply, and it will start working with `Cmd+Space` when Toshy is enabled. And also it will now work even when Toshy is disabled. There are other identically named shortcut settings in the main KDE control panel for shortcuts, but they seem to want to open `krunner`, the search/launcher bar that pops out from the top of the screen.  
 
 ### More Will Follow...
 

--- a/lib/env.py
+++ b/lib/env.py
@@ -73,7 +73,10 @@ def get_env_info():
     if release_files['/etc/os-release']:
         for line in release_files['/etc/os-release']:
             line: str
-            if line.startswith('NAME='):
+            if line.startswith('ID='):
+                _distro_name = line.split('=')[1].strip().strip('"')
+                break
+            elif line.startswith('NAME='):
                 _distro_name = line.split('=')[1].strip().strip('"')
                 break
             elif line.startswith('PRETTY_NAME='):

--- a/packages.json
+++ b/packages.json
@@ -203,6 +203,20 @@
         "systemd",
         "tk"
     ],
+    "arcolinux": [
+        "cairo",
+        "dbus",
+        "evtest",
+        "git",
+        "gobject-introspection",
+        "libappindicator-gtk3",
+        "pkg-config",
+        "python",
+        "python-dbus",
+        "python-pip",
+        "systemd",
+        "tk"
+    ],
     "endeavouros": [
         "cairo",
         "dbus",

--- a/toshy-default-config/toshy_config.py
+++ b/toshy-default-config/toshy_config.py
@@ -684,7 +684,7 @@ keyboards_IBM = [
     'IBM Rapid Access Keyboard',
     'IBM Space Saver II',
     'IBM Model M',
-    'IBM Model F',    
+    'IBM Model F',
 ]
 keyboards_Chromebook = [
     # Add specific Chromebook keyboard device names to this list
@@ -701,10 +701,10 @@ keyboards_Apple = [
 ]
 
 kbtype_lists = {
-    'IBM': keyboards_IBM, 
-    'Chromebook': keyboards_Chromebook, 
-    'Windows': keyboards_Windows, 
-    'Apple': keyboards_Apple
+    'IBM':          keyboards_IBM, 
+    'Chromebook':   keyboards_Chromebook, 
+    'Windows':      keyboards_Windows, 
+    'Apple':        keyboards_Apple
 }
 
 # List of all known keyboard devices from all lists

--- a/toshy-default-config/toshy_config.py
+++ b/toshy-default-config/toshy_config.py
@@ -701,9 +701,9 @@ keyboards_Apple = [
 ]
 
 kbtype_lists = {
-    'IBM':          keyboards_IBM, 
-    'Chromebook':   keyboards_Chromebook, 
-    'Windows':      keyboards_Windows, 
+    'IBM':          keyboards_IBM,
+    'Chromebook':   keyboards_Chromebook,
+    'Windows':      keyboards_Windows,
     'Apple':        keyboards_Apple
 }
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -329,7 +329,7 @@ def install_distro_pkgs():
     apt_distros = ['ubuntu', 'mint', 'lmde', 'popos', 'eos', 'neon', 'zorin', 'debian']
     dnf_distros_Fedora = ['fedora', 'fedoralinux']
     dnf_distros_RHEL = ['almalinux', 'rocky', 'rhel']
-    pacman_distros = ['arch', 'endeavouros', 'manjaro']
+    pacman_distros = ['arch', 'arcolinux', 'endeavouros', 'manjaro']
     zypper_distros = ['opensuse-tumbleweed']
 
     if cnfg.DISTRO_NAME in apt_distros:

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -770,7 +770,8 @@ def apply_desktop_tweaks():
                 subprocess.run(f'mv "{otf_dir}/{file}" ~/.local/share/fonts/', shell=True)
         
         # Update the font cache
-        subprocess.run('fc-cache -f -v', shell=True)
+        subprocess.run('fc-cache -f -v', shell=True,
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         print(f'Installed font: {folder_name}')
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -744,7 +744,8 @@ def apply_desktop_tweaks():
         font_url    = 'https://github.com/spinda/fantasque-sans-ligatures/releases/download/v1.8.1'
         font_link   = f'{font_url}/{font_file}'
         subprocess.run(
-            f'curl -LO "{font_link}" || wget --trust-server-names "{font_link}"', shell=True)
+            f'curl -LO "{font_link}" || wget --trust-server-names "{font_link}"', shell=True,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         zip_path    = f'./{font_file}'
         folder_name = font_file.rsplit('.', 1)[0]
@@ -773,7 +774,7 @@ def apply_desktop_tweaks():
         subprocess.run('fc-cache -f -v', shell=True,
                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-        print(f'Installed font: {folder_name}')
+        print(f'\nInstalled font: {folder_name}')
 
     if not cnfg.tweak_applied:
         print(f'If nothing printed, no tweaks available for "{cnfg.DESKTOP_ENV}" yet.')

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -941,6 +941,7 @@ def main(cnfg: InstallerSettings):
 
     if cnfg.remind_extensions or (cnfg.DESKTOP_ENV == 'gnome' and cnfg.SESSION_TYPE == 'wayland'):
         print(f'MUST INSTALL GNOME EXTENSIONS IF USING WAYLAND SESSION. See README.')
+        
 
     if not cnfg.should_reboot:
         # Try to start the tray icon immediately, if reboot is not indicated
@@ -960,6 +961,8 @@ def main(cnfg: InstallerSettings):
                 f'Rebooting should not be necessary.\n'
                 f'{cnfg.separator}\n'
         )
+        if cnfg.SESSION_TYPE == 'wayland' and cnfg.DESKTOP_ENV == 'kde':
+            print(f'SWITCH TO A DIFFERENT WINDOW ONCE TO GET KWIN SCRIPT TO START WORKING!')
 
     print('')   # blank line to avoid crowding the prompt after install is done
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -746,21 +746,33 @@ def apply_desktop_tweaks():
         subprocess.run(
             f'curl -LO "{font_link}" || wget --trust-server-names "{font_link}"', shell=True)
 
-        zip_path = './FantasqueSansMono-LargeLineHeight-NoLoopK-NameSuffix.zip'
+        zip_path    = f'./{font_file}'
+        folder_name = font_file.rsplit('.', 1)[0]
         extract_dir = '/tmp/'
 
+        # Open the zip file and check if it has a top-level directory
         with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+            # Get the first part of each path in the zip file
+            top_dirs = {name.split('/')[0] for name in zip_ref.namelist()}
+            
+            # If the zip doesn't have a consistent top-level directory, create one and adjust extract_dir
+            if len(top_dirs) > 1:
+                extract_dir = os.path.join(extract_dir, folder_name)
+                os.makedirs(extract_dir, exist_ok=True)
+            
             zip_ref.extractall(extract_dir)
 
-        otf_dir = '/tmp/FantasqueSansMono-LargeLineHeight-NoLoopK-NameSuffix/OTF/'
+        otf_dir = f'{extract_dir}/OTF/'
         os.makedirs(os.path.expanduser('~/.local/share/fonts'), exist_ok=True)
 
         for file in os.listdir(otf_dir):
             if file.endswith('.otf'):
                 subprocess.run(f'mv "{otf_dir}/{file}" ~/.local/share/fonts/', shell=True)
+        
         # Update the font cache
         subprocess.run('fc-cache -f -v', shell=True)
-        print(f'Installed font: Fantasque Sans Mono noLig (no ligatures, NoLoopK, LargeLineHeight)')
+
+        print(f'Installed font: {folder_name}')
 
     if not cnfg.tweak_applied:
         print(f'If nothing printed, no tweaks available for "{cnfg.DESKTOP_ENV}" yet.')

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -80,7 +80,10 @@ class InstallerSettings:
         self.input_group_name   = 'input'
         self.user_name          = pwd.getpwuid(os.getuid()).pw_name
 
+        self.fancy_pants        = None
         self.tweak_applied      = None
+        self.remind_extensions  = None
+
         self.should_reboot      = None
         self.reboot_tmp_file    = "/tmp/toshy_installer_says_reboot"
         self.reboot_ascii_art   = textwrap.dedent("""
@@ -448,7 +451,8 @@ def install_toshy_files():
                 'LICENSE',
                 '.gitignore',
                 'packages.json',
-                'README.md'
+                'README.md',
+                'kwin-application-switcher'
             )
         )
     except shutil.Error as copy_error:
@@ -653,7 +657,7 @@ def autostart_tray_icon():
     print(f'Tray icon should appear in system tray at each login.')
 
 
-def apply_kde_tweak():
+def apply_kde_tweaks():
     """Add a tweak to kwinrc file to disable Meta key opening app menu."""
 
     subprocess.run(
@@ -664,9 +668,25 @@ def apply_kde_tweak():
                     stderr=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL)
     print(f'Disabled Meta key opening application menu.')
+    
+    if cnfg.fancy_pants:
+        # How to install nclarius grouped "Application Switcher" KWin script:
+        # git clone https://github.com/nclarius/kwin-application-switcher.git
+        # cd kwin-application-switcher
+        # ./install.sh
+        switcher_url    = 'https://github.com/nclarius/kwin-application-switcher.git'
+        script_path     = os.path.dirname(os.path.realpath(__file__))
+        # git should be installed by this point? Not necessarily.
+        if shutil.which('git'):
+            subprocess.run(f"git clone {switcher_url}", shell=True)
+            command_dir     = os.path.join(script_path, 'kwin-application-switcher')
+            subprocess.run(f"./install.sh", cwd=command_dir, shell=True)
+            print(f'Installed "Application Switcher" KWin script.')
+        else:
+            print(f"ERROR: Unable to clone KWin Application Switcher. 'git' not installed.")
 
 
-def remove_kde_tweak():
+def remove_kde_tweaks():
     """Remove the tweak to kwinrc file that disables Meta key opening app menu."""
 
     subprocess.run(
@@ -696,7 +716,7 @@ def apply_desktop_tweaks():
     # gsettings set org.gnome.mutter overlay-key ''
     if cnfg.DESKTOP_ENV == 'gnome':
         subprocess.run(['gsettings', 'set', 'org.gnome.mutter', 'overlay-key', ''])
-        print(f'Disabling Super/Meta/Win/Cmd key opening the GNOME overview...')
+        print(f'Disabled Super/Meta/Win/Cmd key opening the GNOME overview.')
         cnfg.tweak_applied = True
 
         def is_extension_enabled(extension_uuid):
@@ -713,11 +733,35 @@ def apply_desktop_tweaks():
                 "Easiest method: 'flatpak install extensionmanager', search for 'appindicator'")
 
     if cnfg.DESKTOP_ENV == 'kde':
-        apply_kde_tweak()
+        apply_kde_tweaks()
         cnfg.tweak_applied = True
     
     # if KDE, install `ibus` or `fcitx` and choose as input manager (ask for confirmation)
-    
+
+    if cnfg.fancy_pants:
+        # install Fantasque Sans Mono NoLig (no ligatures) from GitHub fork
+        font_file   = 'FantasqueSansMono-LargeLineHeight-NoLoopK-NameSuffix.zip'
+        font_url    = 'https://github.com/spinda/fantasque-sans-ligatures/releases/download/v1.8.1'
+        font_link   = f'{font_url}/{font_file}'
+        subprocess.run(
+            f'curl -LO "{font_link}" || wget --trust-server-names "{font_link}"', shell=True)
+
+        zip_path = './FantasqueSansMono-LargeLineHeight-NoLoopK-NameSuffix.zip'
+        extract_dir = '/tmp/'
+
+        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+            zip_ref.extractall(extract_dir)
+
+        otf_dir = '/tmp/FantasqueSansMono-LargeLineHeight-NoLoopK-NameSuffix/OTF/'
+        os.makedirs(os.path.expanduser('~/.local/share/fonts'), exist_ok=True)
+
+        for file in os.listdir(otf_dir):
+            if file.endswith('.otf'):
+                subprocess.run(f'mv "{otf_dir}/{file}" ~/.local/share/fonts/', shell=True)
+        # Update the font cache
+        subprocess.run('fc-cache -f -v', shell=True)
+        print(f'Installed font: Fantasque Sans Mono noLig (no ligatures, NoLoopK, LargeLineHeight)')
+
     if not cnfg.tweak_applied:
         print(f'If nothing printed, no tweaks available for "{cnfg.DESKTOP_ENV}" yet.')
 
@@ -734,7 +778,7 @@ def remove_desktop_tweaks():
         print(f'Removed tweak to disable GNOME "overlay-key" binding to Meta/Super.')
 
     if cnfg.DESKTOP_ENV == 'kde':
-        remove_kde_tweak()
+        remove_kde_tweaks()
         print(f'Removed tweak to disable Meta opening KDE application menu.')
 
 
@@ -790,20 +834,22 @@ def handle_arguments():
     parser.add_argument(
         '--show-env',
         action='store_true',
-        # dest='show_env',
         help='Show the environment the installer detects, and exit'
     )
     parser.add_argument(
         '--apply-tweaks',
         action='store_true',
-        # dest='apply_tweaks',
         help='Apply desktop environment tweaks only, no install'
     )
     parser.add_argument(
         '--remove-tweaks',
         action='store_true',
-        # dest='remove_tweaks',
         help='Remove desktop environment tweaks only, no install'
+    )
+    parser.add_argument(
+        '--fancy-pants',
+        action='store_true',
+        help='Optional: install fonts, KDE task switcher, etc...'
     )
 
     args = parser.parse_args()
@@ -830,6 +876,9 @@ def handle_arguments():
     elif args.uninstall:
         raise NotImplementedError
         uninstall_toshy()
+    elif args.fancy_pants:
+        cnfg.fancy_pants = True
+        main(cnfg)
     else:
         # proceed with normal install sequence if no CLI args given
         main(cnfg)
@@ -876,6 +925,9 @@ def main(cnfg: InstallerSettings):
                 '>>> ALERT: Permissions changed. You MUST reboot for Toshy to work...\n'
                 f'{cnfg.separator}\n'
         )
+
+    if cnfg.remind_extensions or (cnfg.DESKTOP_ENV == 'gnome' and cnfg.SESSION_TYPE == 'wayland'):
+        print(f'MUST INSTALL GNOME EXTENSIONS IF USING WAYLAND SESSION. See README.')
 
     if not cnfg.should_reboot:
         # Try to start the tray icon immediately, if reboot is not indicated


### PR DESCRIPTION
README updates: 

- CLI options for setup
- Reorganize the "working distros" section
- Arcolinux

Environment module: 

- Get "ID" of distro before trying to get "NAME". 

packages.json:

- Add Arcolinux package list

Installer updates: 

- Arcolinux support
- Reminders about extensions and KWin script fix at end of install
- Fancy installer option

