### PR TITLE
Update toshy_setup.py

### DIFF
--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -62,7 +62,7 @@ class InstallerSettings:
         self.pkgs_json_dct      = None
         self.pkgs_for_distro    = None
         self.pip_pkgs           = None
-        self.qdbus              = 'qdbus-qt5' if shutil.which('qdbus-qt5') else cnfg.qdbus
+        self.qdbus              = 'qdbus-qt5' if shutil.which('qdbus-qt5') else None
 
         self.home_dir_path      = os.path.abspath(os.path.expanduser('~'))
         self.toshy_dir_path     = os.path.join(self.home_dir_path, '.config', 'toshy')


### PR DESCRIPTION
Original code sets `self.qdbus = 'qdbus-qt5' if shutil.which('qdbus-qt5') else cnfg.qdbus` but `cnfg` is undefined. This causes an error at runtime. Setting to `None` removes the error and allows it to work on Ubuntu Gnome X11.