### PR TITLE
Retain user customizations and preferences through reinstalls

### DIFF
--- a/lib/env.py
+++ b/lib/env.py
@@ -237,29 +237,31 @@ def get_env_info():
         error(f'Desktop Environment not in de_names list! Should fix this.\n\t{_desktop_env = }')
         DESKTOP_ENV = _desktop_env
 
-    # Doublecheck the desktop environment by checking for identifiable running processes
-    def check_process(names, desktop_env):
-        nonlocal DESKTOP_ENV
-        for name in names:
-            command = f"pgrep {name}"
-            try:
-                subprocess.check_output(command, shell=True)
-                if DESKTOP_ENV != desktop_env:
-                    error(  f"Desktop may be misidentified: '{DESKTOP_ENV}'\n"
-                            f"'{desktop_env}' was detected and will be used instead.")
-                    DESKTOP_ENV = desktop_env
-                break  # Stop checking if any of the processes are found
-            except subprocess.CalledProcessError:
-                pass
+    # do this only if DESKTOP_ENV is still None after the above step
+    if not DESKTOP_ENV:
+        # Doublecheck the desktop environment by checking for identifiable running processes
+        def check_process(names, desktop_env):
+            nonlocal DESKTOP_ENV
+            for name in names:
+                command = f"pgrep {name}"
+                try:
+                    subprocess.check_output(command, shell=True)
+                    if DESKTOP_ENV != desktop_env:
+                        error(  f"Desktop may be misidentified: '{DESKTOP_ENV}'\n"
+                                f"'{desktop_env}' was detected and will be used instead.")
+                        DESKTOP_ENV = desktop_env
+                    break  # Stop checking if any of the processes are found
+                except subprocess.CalledProcessError:
+                    pass
 
-    processes = {
-        'kde': ['plasmashell', 'kwin_ft', 'kwin_wayland', 'kwin_x11'],
-        'gnome': ['gnome-shell'],
-        'sway': ['sway']
-    }
+        processes = {
+            'kde': ['plasmashell', 'kwin_ft', 'kwin_wayland', 'kwin_x11'],
+            'gnome': ['gnome-shell'],
+            'sway': ['sway']
+        }
 
-    for desktop_env, process_names in processes.items():
-        check_process(process_names, desktop_env)
+        for desktop_env, process_names in processes.items():
+            check_process(process_names, desktop_env)
 
 
     env_info_dct['DESKTOP_ENV'] = DESKTOP_ENV

--- a/toshy-default-config/toshy_config.py
+++ b/toshy-default-config/toshy_config.py
@@ -678,8 +678,9 @@ dialogs_Escape_lod = [
     {clas:"^.*nautilus$",                name:"^.*Properties$|^Preferences$|^Create Archive$"},
     {clas:"^Transmission-gtk$|^com.transmissionbt.Transmission.*$", not_name:"^Transmission$"},
     {clas:"^org.gnome.Software$",        not_name:"^Software$"},
-    {clas:"^gnome-text-editor|org.gnome.TextEditor$", name:"^Preferences$"},
+    {clas:"^gnome-text-editor$|^org.gnome.TextEditor$", name:"^Preferences$"},
     {clas:"^org.gnome.Shell.Extensions$"},
+    {clas:"^konsole$|^org.kde.konsole$", name:"^Configure.*Konsole$|^Edit Profile.*Konsole$"},
 ]
 
 ### dialogs_CloseWin_lod = send these windows the "Close window" combo for Cmd+W

--- a/toshy-default-config/toshy_config.py
+++ b/toshy-default-config/toshy_config.py
@@ -14,18 +14,25 @@ from keyszer.lib.key_context import KeyContext
 from keyszer.config_api import *
 
 
+###  SLICE_MARK_START: keyszer_api  ###  CHANGES MADE OUTSIDE THESE MARKS WILL BE IGNORED ON UPGRADE
+
 # Keyszer-specific config settings - REMOVE OR SET TO DEFAULTS FOR DISTRIBUTION
 dump_diagnostics_key(Key.F15)   # default key: F15
 emergency_eject_key(Key.F16)    # default key: F16
+
 timeouts(
-    multipurpose    = 1,        # default: 1 sec
-    suspend         = 1,        # default: 1 sec, try 0.1 sec for touchpads
+    multipurpose        = 1,        # default: 1 sec
+    suspend             = 1,        # default: 1 sec, try 0.1 sec for touchpads
 )
+
 # Delays often needed for Wayland (at least in GNOME using shell extensions)
 throttle_delays(
-    key_pre_delay_ms  = 10,      # default: 0 ms, range: 0-150 ms, suggested: 1-50 ms
-    key_post_delay_ms = 15,      # default: 0 ms, range: 0-150 ms, suggested: 1-100 ms
+    key_pre_delay_ms    = 8,      # default: 0 ms, range: 0-150 ms, suggested: 1-50 ms
+    key_post_delay_ms   = 12,      # default: 0 ms, range: 0-150 ms, suggested: 1-100 ms
 )
+
+###  SLICE_MARK_END: keyszer_api  ###  CHANGES MADE OUTSIDE THESE MARKS WILL BE IGNORED ON UPGRADE
+
 
 
 ###############################################################################
@@ -55,7 +62,7 @@ from lib.settings_class import Settings
 # Toshy config file
 TOSHY_PART      = 'config'   # CUSTOMIZE TO SPECIFIC TOSHY COMPONENT! (gui, tray, config)
 TOSHY_PART_NAME = 'Toshy Config file'
-APP_VERSION     = '2023.0516'
+APP_VERSION     = '2023.0604'
 
 # Settings object used to tweak preferences "live" between gui, tray and config.
 cnfg = Settings(config_dir_path)
@@ -78,11 +85,15 @@ debug(cnfg, ctx="CG")
 ##########################################################################
 # Set up some useful environment variables
 
+###  SLICE_MARK_START: env_overrides  ###  CHANGES MADE OUTSIDE THESE MARKS WILL BE IGNORED ON UPGRADE
+
 # MANUALLY set any environment information if the auto-identification isn't working:
 OVERRIDE_DISTRO_NAME     = None
 OVERRIDE_DISTRO_VER      = None
 OVERRIDE_SESSION_TYPE    = None
 OVERRIDE_DESKTOP_ENV     = None
+
+###  SLICE_MARK_END: env_overrides  ###  CHANGES MADE OUTSIDE THESE MARKS WILL BE IGNORED ON UPGRADE
 
 # leave all of this alone!
 DISTRO_NAME     = None
@@ -462,44 +473,45 @@ def negRgx(rgx_str):
 ###                                                ###
 ######################################################
 
-# Use the following for testing terminal keymaps
-# terminals = [ "", ... ]
-# xbindkeys -mk
-terminals = [
-    "alacritty",
-    "cutefish-terminal",
-    "deepin-terminal",
-    "eterm",
-    "gnome-terminal",
-    "gnome-terminal-server",
-    "guake",
-    "hyper",
-    "io.elementary.terminal",
-    "kinto-gui.py",
-    "kitty",
-    "Kgx",                      # GNOME Console terminal app
-    "konsole",
-    "lxterminal",
-    "mate-terminal",
-    "org.gnome.Console",
-    "org.kde.konsole",
-    "roxterm",
-    "qterminal",
-    "st",
-    "sakura",
-    "station",
-    "tabby",
-    "terminator",
-    "termite",
-    "tilda",
-    "tilix",
-    "urxvt",
-    "xfce4-terminal",
-    "xterm",
-    "yakuake",
-]
-terminals = [x.casefold() for x in terminals]
-termStr = toRgxStr(terminals)
+# # OBSOLETED by the "list of dicts" `terminals_lod` below
+# # Use the following for testing terminal keymaps
+# # terminals = [ "", ... ]
+# # xbindkeys -mk
+# terminals = [
+#     "alacritty",
+#     "cutefish-terminal",
+#     "deepin-terminal",
+#     "eterm",
+#     "gnome-terminal",
+#     "gnome-terminal-server",
+#     "guake",
+#     "hyper",
+#     "io.elementary.terminal",
+#     "kinto-gui.py",
+#     "kitty",
+#     "Kgx",  # GNOME Console terminal app (comes from "King's Cross")
+#     "konsole",
+#     "lxterminal",
+#     "mate-terminal",
+#     "org.gnome.Console",
+#     "org.kde.konsole",
+#     "roxterm",
+#     "qterminal",
+#     "st",
+#     "sakura",
+#     "station",
+#     "tabby",
+#     "terminator",
+#     "termite",
+#     "tilda",
+#     "tilix",
+#     "urxvt",
+#     "xfce4-terminal",
+#     "xterm",
+#     "yakuake",
+# ]
+# terminals = [x.casefold() for x in terminals]
+# termStr = toRgxStr(terminals)
 
 terminals_lod = [
     {clas:"^alacritty$"                 },
@@ -535,6 +547,7 @@ terminals_lod = [
     {clas:"^yakuake$"                   },
 ]
 
+# TODO: remove usage of this in favor of `vscodes_lod` below it
 vscodes = [
     "code",
     "vscodium",
@@ -593,9 +606,10 @@ remotes_lod = [
     {clas:"^Wfica$"                      },
 ]
 
-# Add remote desktop clients & VMs for no remapping
-terminals.extend(remotes)
-termStr_ext = toRgxStr(terminals)
+# # OBSOLETED by "list of dicts" `terminals_lod` above
+# # Add remote desktop clients & VMs for no remapping
+# terminals.extend(remotes)
+# termStr_ext = toRgxStr(terminals)
 
 terminals_and_remotes_lod = [
     {lst:terminals_lod                  },
@@ -659,10 +673,10 @@ filemanagers = [
 filemanagers = [x.casefold() for x in filemanagers]
 filemanagerStr = "|".join(str('^'+x+'$') for x in filemanagers)
 
-### dialogs_Esc_lod = send these windows the Escape key for Cmd+W
-dialogs_Esc_lod = [
+### dialogs_Escape_lod = send these windows the Escape key for Cmd+W
+dialogs_Escape_lod = [
     {clas:"^.*nautilus$",                name:"^.*Properties$|^Preferences$|^Create Archive$"},
-    {clas:"^Transmission-gtk$|^com.transmissionbt.Transmission.*$",          not_name:"^Transmission$"},
+    {clas:"^Transmission-gtk$|^com.transmissionbt.Transmission.*$", not_name:"^Transmission$"},
     {clas:"^org.gnome.Software$",        not_name:"^Software$"},
     {clas:"^gnome-text-editor|org.gnome.TextEditor$", name:"^Preferences$"},
     {clas:"^org.gnome.Shell.Extensions$"},
@@ -2568,7 +2582,13 @@ keymap("OptSpecialChars - US", {
 ###                                                                                ###
 ###                                                                                ###
 ######################################################################################
-### Good place for adding new custom keymaps for user applications and custom function keys
+### This is a good location in the config file for adding new custom keymaps for 
+### user applications and custom function keys. Watch out that you don't override 
+### any "general" shortcuts like Cmd+Z/X/C/V that may be defined below this section. 
+### Changes made between the "slice" marks will be retained by the Toshy installer 
+### if you reinstall and it finds matching start/end markers for each section. 
+
+###  SLICE_MARK_START: user_apps  ###  CHANGES MADE OUTSIDE THESE MARKS WILL BE IGNORED ON UPGRADE
 
 # REMOVE THE CONTENTS OF THIS FOR GENERAL USE
 keymap("User hardware keys", {
@@ -2576,6 +2596,8 @@ keymap("User hardware keys", {
 # }, when = lambda ctx: ctx.wm_class.casefold() not in remotes)
 # }, when = matchProps(not_clas=remoteStr))
 }, when = matchProps(not_lst=remotes_lod))
+
+###  SLICE_MARK_END: user_apps  ###  CHANGES MADE OUTSIDE THESE MARKS WILL BE IGNORED ON UPGRADE
 
 
 
@@ -3034,18 +3056,28 @@ keymap("Wordwise - not vscode", {
 # Keybindings for VS Code and variants
 keymap("VSCodes overrides for Chromebook/IBM - Sublime", {
     C("C-Alt-g"):               C("C-f2"),                      # Chromebook/IBM - Sublime - find_all_under
-}, when = lambda ctx: matchProps(clas=vscodeStr)(ctx) and ( isKBtype('Chromebook')(ctx) or isKBtype('IBM')(ctx) ) and cnfg.ST3_in_VSCode)
+}, when = lambda ctx:
+    matchProps(clas=vscodeStr)(ctx) and 
+    ( isKBtype('Chromebook')(ctx) or isKBtype('IBM')(ctx) ) and 
+    cnfg.ST3_in_VSCode)
 keymap("VSCodes overrides for not Chromebook/IBM - Sublime", {
     C("Super-C-g"):             C("C-f2"),                      # Default - Sublime - find_all_under
-}, when = lambda ctx: matchProps(clas=vscodeStr)(ctx) and not ( isKBtype('Chromebook')(ctx) or isKBtype('IBM')(ctx) ) and cnfg.ST3_in_VSCode)
+}, when = lambda ctx:
+    matchProps(clas=vscodeStr)(ctx) and 
+    not ( isKBtype('Chromebook')(ctx) or 
+    isKBtype('IBM')(ctx) ) and cnfg.ST3_in_VSCode)
 keymap("VSCodes overrides for Chromebook/IBM", {
     C("Alt-c"):                 C("LC-c"),                      #  Chromebook/IBM - Terminal - Sigint
     C("Alt-x"):                 C("LC-x"),                      #  Chromebook/IBM - Terminal - Exit nano
-}, when = lambda ctx: matchProps(clas=vscodeStr)(ctx) and ( isKBtype('Chromebook')(ctx) or isKBtype('IBM')(ctx) ) )
+}, when = lambda ctx:
+    matchProps(clas=vscodeStr)(ctx) and 
+    ( isKBtype('Chromebook')(ctx) or isKBtype('IBM')(ctx) ) )
 keymap("VSCodes overrides for not Chromebook/IBM", {
     C("Super-c"):               C("LC-c"),                      # Default - Terminal - Sigint
     C("Super-x"):               C("LC-x"),                      # Default - Terminal - Exit nano
-}, when = lambda ctx: matchProps(clas=vscodeStr)(ctx) and not ( isKBtype('Chromebook')(ctx) or isKBtype('IBM')(ctx) ) )
+}, when = lambda ctx:
+    matchProps(clas=vscodeStr)(ctx) and 
+    not ( isKBtype('Chromebook')(ctx) or isKBtype('IBM')(ctx) ) )
 keymap("VSCodes", {
     # C("Super-Space"):           C("LC-Space"),                  # Basic code completion (conflicts with input switching)
 
@@ -3104,13 +3136,17 @@ keymap("Sublime Text overrides for Chromebook/IBM", {
     C("Alt-x"):                 C("LC-x"),                      #  Chromebook/IBM - Terminal - Exit nano
     C("Alt-Refresh"):           ignore_combo,                   # Chromebook/IBM - cancel find_all_under
     C("Alt-C-g"):               C("Alt-Refresh"),               # Chromebook/IBM - find_all_under
-}, when = lambda ctx: matchProps(clas=sublimeStr)(ctx) and ( isKBtype('Chromebook')(ctx) or isKBtype('IBM')(ctx) ) )
+}, when = lambda ctx:
+    matchProps(clas=sublimeStr)(ctx) and 
+    ( isKBtype('Chromebook')(ctx) or isKBtype('IBM')(ctx) ) )
 keymap("Sublime Text overrides for not Chromebook/IBM", {
     # C("Super-c"):               C("LC-c"),                      # Default - Terminal - Sigint
     # C("Super-x"):               C("LC-x"),                      # Default - Terminal - Exit nano
     C("Alt-f3"):                ignore_combo,                   # Default - cancel find_all_under
     C("Super-C-g"):             C("Alt-f3"),                    # Default - find_all_under
-}, when = lambda ctx: matchProps(clas=sublimeStr)(ctx) and not ( isKBtype('Chromebook')(ctx) or isKBtype('IBM')(ctx) ) )
+}, when = lambda ctx:
+    matchProps(clas=sublimeStr)(ctx) and 
+    not ( isKBtype('Chromebook')(ctx) or isKBtype('IBM')(ctx) ) )
 keymap("Sublime Text", {
     # C("Super-c"):               C("LC-c"),                      # Default - Terminal - Sigint
     # C("Super-x"):               C("LC-x"),                      # Default - Terminal - Exit nano
@@ -3185,6 +3221,7 @@ keymap("Linux Mint xed text editor", {
 }, when = matchProps(clas="^xed$") )
 
 
+
 ###########################  DIALOG FIXES  ###########################
 ###                                                                ###
 ###                                                                ###
@@ -3198,20 +3235,20 @@ keymap("Linux Mint xed text editor", {
 ######################################################################
 ### Fixes for the problem of modal dialogs and other "child" 
 ### windows failing to close with Cmd+W.
-### Many dialogs respond to the Escape key, others may 
-### require the "Close window" shortcut (normally Alt+F4 but not always) to close.
+### Many dialogs respond to the Escape key, others may require the 
+### "Close window" shortcut (normally Alt+F4 but not always) to close.
 ### 
 ### Cmd+W can't just be always mapped to the "Close window" shortcut for all apps 
 ### because some apps will "quit" rather than just closing a tab.
 ### 
 ### To add window conditions to the list, search for the list names in 
 ### the "LISTS" section near the top of this config file. 
-### dialogs_Esc_lod = send these windows the Escape key for Cmd+W
+### dialogs_Escape_lod = send these windows the Escape key for Cmd+W
 ### dialogs_CloseWin_lod = send these windows the "Close window" shortcut for Cmd+W
 
 keymap("Cmd+W dialog fix - send Escape", {
     C("RC-W"):                  C("Esc"),
-}, when = matchProps(lst=dialogs_Esc_lod))
+}, when = matchProps(lst=dialogs_Escape_lod))
 
 
 keymap("Cmd+W dialog fix - Super+Q Manjaro GNOME", {
@@ -3315,38 +3352,45 @@ keymap("Kitty terminal - not tab nav", {
 keymap("GenTerms overrides: elementary OS", {
     C("LC-Right"):              [bind,C("Super-Right")],        # SL - Change workspace (eos)
     C("LC-Left"):               [bind,C("Super-Left")],         # SL - Change workspace (eos)
-}, when = lambda ctx: matchProps(clas=termStr)(ctx) and DISTRO_NAME == 'eos')
+# }, when = lambda ctx: matchProps(clas=termStr)(ctx) and DISTRO_NAME == 'eos')
+}, when = lambda ctx: matchProps(lst=terminals_lod)(ctx) and DISTRO_NAME == 'eos')
 keymap("GenTerms overrides: Fedora", {
     C("RC-H"):                  C("Super-h"),                   # Hide Window/Minimize app (gnome/fedora)
-}, when = lambda ctx: matchProps(clas=termStr)(ctx) and DISTRO_NAME in ['fedora', 'almalinux'] )
+# }, when = lambda ctx: matchProps(clas=termStr)(ctx) and DISTRO_NAME in ['fedora', 'almalinux'] )
+}, when = lambda ctx: matchProps(lst=terminals_lod)(ctx) and DISTRO_NAME in ['fedora', 'almalinux'] )
 keymap("GenTerms overrides: Pop!_OS", {
     C("LC-Right"):              [bind,C("Super-C-Up")],         # SL - Change workspace (popos)
     C("LC-Left"):               [bind,C("Super-C-Down")],       # SL - Change workspace (popos)
-}, when = lambda ctx: matchProps(clas=termStr)(ctx) and DISTRO_NAME == 'popos')
+# }, when = lambda ctx: matchProps(clas=termStr)(ctx) and DISTRO_NAME == 'popos')
+}, when = lambda ctx: matchProps(lst=terminals_lod)(ctx) and DISTRO_NAME == 'popos')
 keymap("GenTerms overrides: Ubuntu/Fedora", {
     C("LC-Right"):              [bind,C("Super-Page_Up")],      # SL - Change workspace (ubuntu/fedora)
     C("LC-Left"):               [bind,C("Super-Page_Down")],    # SL - Change workspace (ubuntu/fedora)
-}, when = lambda ctx: matchProps(clas=termStr)(ctx) and DISTRO_NAME in ['ubuntu', 'fedora'] )
+# }, when = lambda ctx: matchProps(clas=termStr)(ctx) and DISTRO_NAME in ['ubuntu', 'fedora'] )
+}, when = lambda ctx: matchProps(lst=terminals_lod)(ctx) and DISTRO_NAME in ['ubuntu', 'fedora'] )
 
 
 # Overrides to General Terminals shortcuts for specific desktop environments
 keymap("GenTerms overrides: Budgie", {
     C("LC-Right"):              [bind,C("C-Alt-Right")],        # Default SL - Change workspace (budgie)
     C("LC-Left"):               [bind,C("C-Alt-Left")],         # Default SL - Change workspace (budgie)
-}, when = lambda ctx: matchProps(clas=termStr)(ctx) and DESKTOP_ENV == 'budgie' )
+# }, when = lambda ctx: matchProps(clas=termStr)(ctx) and DESKTOP_ENV == 'budgie' )
+}, when = lambda ctx: matchProps(lst=terminals_lod)(ctx) and DESKTOP_ENV == 'budgie' )
 keymap("GenTerms overrides: GNOME", {
     ### Keyboard input source (language/layout) switching in GNOME
     # C("LC-Space"):              update_kb_layout,             # keyboard input source (language) switching (gnome)
     # C("Shift-LC-Space"):        update_kb_layout,             # keyboard input source (language) switching (reverse) (gnome)
     C("LC-Space"):             [bind,C("Super-Space")],         # keyboard input source (language) switching (gnome)
     C("Shift-LC-Space"):       [bind,C("Super-Shift-Space")],   # keyboard input source (language) switching (reverse) (gnome)
-}, when = lambda ctx: matchProps(clas=termStr)(ctx) and DESKTOP_ENV == 'gnome' )
+# }, when = lambda ctx: matchProps(clas=termStr)(ctx) and DESKTOP_ENV == 'gnome' )
+}, when = lambda ctx: matchProps(lst=terminals_lod)(ctx) and DESKTOP_ENV == 'gnome' )
 keymap("GenTerms overrides: Xfce4", {
     C("RC-Grave"):             [bind,C("Super-Tab")],           # xfce4 Switch within app group
     C("Shift-RC-Grave"):       [bind,C("Super-Shift-Tab")],     # xfce4 Switch within app group
     C("LC-Right"):             [bind,C("C-Alt-Home")],          # SL - Change workspace xfce4
     C("LC-Left"):              [bind,C("C-Alt-End")],           # SL - Change workspace xfce4
-}, when = lambda ctx: matchProps(clas=termStr)(ctx) and DESKTOP_ENV == 'xfce' )
+# }, when = lambda ctx: matchProps(clas=termStr)(ctx) and DESKTOP_ENV == 'xfce' )
+}, when = lambda ctx: matchProps(lst=terminals_lod)(ctx) and DESKTOP_ENV == 'xfce' )
 
 
 # Active in all apps in the terminals list
@@ -3409,7 +3453,8 @@ keymap("General Terminals", {
     C("RC-SLASH"):              C("C-Shift-SLASH"),
     C("RC-KPASTERISK"):         C("C-Shift-KPASTERISK"),
 
-}, when = matchProps(clas=termStr))
+# }, when = matchProps(clas=termStr))
+}, when = matchProps(lst=terminals_lod))
 
 
 
@@ -3429,7 +3474,8 @@ keymap("General Terminals", {
 keymap("Cmd+Dot not in terminals", {
     C("RC-Dot"):                C("Esc"),                       # Mimic macOS Cmd+dot = Escape key (not in terminals)
 # }, when = lambda ctx: ctx.wm_class.casefold() not in terminals)
-}, when = matchProps(not_clas=termStr_ext) )
+# }, when = matchProps(not_clas=termStr_ext) )
+}, when = matchProps(not_lst=terminals_and_remotes_lod) )
 
 
 # Overrides to General GUI shortcuts for specific keyboard types

--- a/toshy-default-config/toshy_config.py
+++ b/toshy-default-config/toshy_config.py
@@ -670,11 +670,11 @@ dialogs_Esc_lod = [
 
 ### dialogs_CloseWin_lod = send these windows the "Close window" combo for Cmd+W
 dialogs_CloseWin_lod = [
-    {clas:"^Gnome-control-center$",      not_name:"^Settings$"},
-    {clas:"^gnome-terminal$",            name:"^Preferences.*$"},
-    {clas:"^gnome-terminal-pref.*$",   name:"^Preferences.*$"},
-    {clas:"^pcloud$"                     },
-    {clas:"^Totem$",                     not_name:"^Videos$"},
+    {clas:"^Gnome-control-center$",     not_name:"^Settings$"},
+    {clas:"^gnome-terminal.*$",         name:"^Preferences.*$"},
+    {clas:"^gnome-terminal-pref.*$",    name:"^Preferences.*$"},
+    {clas:"^pcloud$"                    },
+    {clas:"^Totem$",                    not_name:"^Videos$"},
 ]
 
 # Lists of keyboard device names, to match keyboard type

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -53,7 +53,9 @@ else:
 class InstallerSettings:
     """Set up variables for necessary information to be used by all functions"""
     def __init__(self) -> None:
-        self.separator              = '============================================================'
+        sep_reps                    = 80
+        self.sep_char               = '='
+        self.separator              = self.sep_char * sep_reps
         self.env_info_dct           = None
         self.override_distro        = None
         self.DISTRO_NAME            = None

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -95,7 +95,8 @@ class InstallerSettings:
         self.remind_extensions      = None
 
         self.should_reboot          = None
-        self.reboot_tmp_file        = "/tmp/toshy_installer_says_reboot"
+        self.run_tmp_dir            = os.environ.get('XDG_RUNTIME_DIR') or '/tmp'
+        self.reboot_tmp_file        = f"{self.run_tmp_dir}/toshy_installer_says_reboot"
         self.reboot_ascii_art       = textwrap.dedent("""
                 ██████      ███████     ██████       ██████       ██████      ████████     ██ 
                 ██   ██     ██          ██   ██     ██    ██     ██    ██        ██        ██ 
@@ -561,12 +562,12 @@ def backup_toshy_config():
 
         if os.path.isfile(cnfg.db_file_path):
             try:
-                os.unlink(f'/tmp/{cnfg.db_file_name}')
+                os.unlink(f'{cnfg.run_tmp_dir}/{cnfg.db_file_name}')
             except (FileNotFoundError, PermissionError, OSError): pass
             try:
-                shutil.copy(cnfg.db_file_path, '/tmp/')
+                shutil.copy(cnfg.db_file_path, f'{cnfg.run_tmp_dir}/')
             except (FileNotFoundError, PermissionError, OSError) as file_err:
-                error(f'Problem copying preferences db file to /tmp:\n\t{file_err}')
+                error(f"Problem copying preferences db file to '{cnfg.run_tmp_dir}':\n\t{file_err}")
 
         try:
             # Define the ignore function
@@ -624,12 +625,12 @@ def install_toshy_files():
     shutil.copy(toshy_default_cfg, cnfg.toshy_dir_path)
     print(f"Toshy files installed in '{cnfg.toshy_dir_path}'.")
 
-    if os.path.isfile(f'/tmp/{cnfg.db_file_name}'):
+    if os.path.isfile(f'{cnfg.run_tmp_dir}/{cnfg.db_file_name}'):
         try:
-            shutil.copy(f'/tmp/{cnfg.db_file_name}', cnfg.toshy_dir_path)
+            shutil.copy(f'{cnfg.run_tmp_dir}/{cnfg.db_file_name}', cnfg.toshy_dir_path)
             print(f'Copied preferences db file from existing config folder.')
         except (FileExistsError, FileNotFoundError, PermissionError, OSError) as file_err:
-            error(f'Problem copying preferences db file from /tmp:\n\t{file_err}')
+            error(f"Problem copying preferences db file from '{cnfg.run_tmp_dir}':\n\t{file_err}")
 
     # Apply user customizations to the new config file.
     new_cfg_file = os.path.join(cnfg.toshy_dir_path, 'toshy_config.py')
@@ -746,7 +747,7 @@ def setup_kwin2dbus_script():
     kwin_script_name    = 'toshy-dbus-notifyactivewindow'
     kwin_script_path    = os.path.join( cnfg.toshy_dir_path,
                                         'kde-kwin-dbus-service', kwin_script_name)
-    temp_file_path      = '/tmp/toshy-dbus-notifyactivewindow.kwinscript'
+    temp_file_path      = f'{cnfg.run_tmp_dir}/toshy-dbus-notifyactivewindow.kwinscript'
 
     # Create a zip file (overwrite if it exists)
     with zipfile.ZipFile(temp_file_path, 'w') as zipf:
@@ -1010,7 +1011,7 @@ def apply_desktop_tweaks():
         
         if os.path.isfile(zip_path):
             folder_name = font_file.rsplit('.', 1)[0]
-            extract_dir = '/tmp/'
+            extract_dir = f'{cnfg.run_tmp_dir}/'
 
             print(f'unzipping... ', end='', flush=True)
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -180,7 +180,7 @@ def dot_Xmodmap_warning():
     if os.path.isfile(xmodmap_file_path):
         print(f'\n{cnfg.separator}')
         print(f"\t WARNING: You have an '.Xmodmap' file in your home folder!!! \n")
-        print(f' This can cause confusing PROBLEMS if you are remapping any modifier keys!')
+        print(f'   This can cause confusing PROBLEMS if you are remapping any modifier keys!')
         print(f'{cnfg.separator}\n')
         
         secret_code = ''.join(random.choice(string.ascii_letters) for _ in range(4))

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -69,7 +69,7 @@ class InstallerSettings:
         self.home_dir_path          = os.path.abspath(os.path.expanduser('~'))
         self.toshy_dir_path         = os.path.join(self.home_dir_path, '.config', 'toshy')
         self.db_file_name           = 'toshy_user_preferences.sqlite'
-        self.db_file_path           = os.path.join(cnfg.toshy_dir_path, self.db_file_name)
+        self.db_file_path           = os.path.join(self.toshy_dir_path, self.db_file_name)
         self.backup_succeeded       = None
         self.existing_cfg_data      = None
         self.existing_cfg_slices    = None

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -180,6 +180,7 @@ def dot_Xmodmap_warning():
     xmodmap_file_path = os.path.realpath(os.path.join(os.path.expanduser('~'), '.Xmodmap'))
     if os.path.isfile(xmodmap_file_path):
         print(f'\n{cnfg.separator}')
+        print(f'{cnfg.separator}')
         if os.environ['COLORTERM']:
             # Terminal supports ANSI escape sequences
             print("\033[1;31m\t WARNING: You have an '.Xmodmap' file in your home folder!!!\033[0m")
@@ -187,6 +188,7 @@ def dot_Xmodmap_warning():
             # Terminal might not support ANSI escape sequences
             print(f"\t WARNING: You have an '.Xmodmap' file in your home folder!!! \n")
         print(f'   This can cause confusing PROBLEMS if you are remapping any modifier keys!')
+        print(f'{cnfg.separator}')
         print(f'{cnfg.separator}\n')
         
         secret_code = ''.join(random.choice(string.ascii_letters) for _ in range(4))

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -734,6 +734,12 @@ def apply_tweaks_GNOME():
                     'switch-group', "['<Alt>grave']"])
     print(f'Enabled "Switch applications" Mac-like task switching.')
     
+    # Enable keyboard shortcut for GNOME Terminal preferences dialog
+    # gsettings set org.gnome.Terminal.Legacy.Keybindings:/org/gnome/terminal/legacy/keybindings/ preferences '<Control>less'
+    cmd_path = 'org.gnome.Terminal.Legacy.Keybindings:/org/gnome/terminal/legacy/keybindings/'
+    prefs_binding = '<Control>less'
+    subprocess.run(['gsettings', 'set', cmd_path, 'preferences', prefs_binding])
+    
     # Enable "Expandable folders" in Nautilus
     # dconf write /org/gnome/nautilus/list-view/use-tree-view true
     subprocess.run(['dconf', 'write', '/org/gnome/nautilus/list-view/use-tree-view', 'true'])

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -880,16 +880,17 @@ def apply_desktop_tweaks():
                 
                 zip_ref.extractall(extract_dir)
 
-            otf_dir         = f'{extract_dir}/OTF/'
+            # use TTF instead of OTF to try and minimize "stem darkening" effect in KDE
+            font_dir        = f'{extract_dir}/TTF/'
             local_fonts_dir = os.path.realpath(os.path.expanduser('~/.local/share/fonts'))
 
             os.makedirs(local_fonts_dir, exist_ok=True)
 
             print(f'moving... ', end='')
 
-            for file in os.listdir(otf_dir):
-                if file.endswith('.otf'):
-                    src_path = os.path.join(otf_dir, file)
+            for file in os.listdir(font_dir):
+                if file.endswith('.ttf'):
+                    src_path = os.path.join(font_dir, file)
                     dest_path = os.path.join(local_fonts_dir, file)
                     shutil.move(src_path, dest_path)
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -535,6 +535,8 @@ def backup_toshy_config():
         if os.path.isfile(cnfg.db_file_path):
             try:
                 os.unlink(f'/tmp/{cnfg.db_file_name}')
+            except (FileNotFoundError, PermissionError, OSError): pass
+            try:
                 shutil.copy(cnfg.db_file_path, '/tmp/')
             except (FileNotFoundError, PermissionError, OSError) as file_err:
                 error(f'Problem copying preferences db file to /tmp:\n\t{file_err}')

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -388,10 +388,10 @@ def install_distro_pkgs():
         # do extra stuff only if distro is a RHEL type (not Fedora)
         if cnfg.DISTRO_NAME not in ['fedora', 'fedoralinux']:
             call_attention_to_password_prompt()
-            # for libappindicator-gtk3: sudo dnf install epel-release
-            subprocess.run(['sudo', 'dnf', 'install', '-y', 'epel-release'])
             # for gobject-introspection-devel: sudo dnf config-manager --set-enabled crb
             subprocess.run(['sudo', 'dnf', 'config-manager', '--set-enabled', 'crb'])
+            # for libappindicator-gtk3: sudo dnf install -y epel-release
+            subprocess.run(['sudo', 'dnf', 'install', '-y', 'epel-release'])
             subprocess.run(['sudo', 'dnf', 'update', '-y'])
         # now do the install of the list of packages
         subprocess.run(['sudo', 'dnf', 'install', '-y'] + cnfg.pkgs_for_distro)

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -989,14 +989,14 @@ def apply_desktop_tweaks():
     # General (not DE specific) "fancy pants" additions:
     if cnfg.fancy_pants:
         
-        print(f'Installing font... ', end='', flush=True)
+        print(f'Installing font: ', end='', flush=True)
 
         # install Fantasque Sans Mono NoLig (no ligatures) from GitHub fork
         font_file   = 'FantasqueSansMono-LargeLineHeight-NoLoopK-NameSuffix.zip'
         font_url    = 'https://github.com/spinda/fantasque-sans-ligatures/releases/download/v1.8.1'
         font_link   = f'{font_url}/{font_file}'
 
-        print(f'downloading... ', end='', flush=True)
+        print(f'Downloading… ', end='', flush=True)
 
         if shutil.which('curl'):
             subprocess.run(['curl', '-LO', font_link], 
@@ -1013,7 +1013,7 @@ def apply_desktop_tweaks():
             folder_name = font_file.rsplit('.', 1)[0]
             extract_dir = f'{cnfg.run_tmp_dir}/'
 
-            print(f'unzipping... ', end='', flush=True)
+            print(f'Unzipping… ', end='', flush=True)
 
             # Open the zip file and check if it has a top-level directory
             with zipfile.ZipFile(zip_path, 'r') as zip_ref:
@@ -1033,7 +1033,7 @@ def apply_desktop_tweaks():
 
             os.makedirs(local_fonts_dir, exist_ok=True)
 
-            print(f'moving... ', end='', flush=True)
+            print(f'Moving… ', end='', flush=True)
 
             for file in os.listdir(font_dir):
                 if file.endswith('.ttf'):
@@ -1041,7 +1041,7 @@ def apply_desktop_tweaks():
                     dest_path = os.path.join(local_fonts_dir, file)
                     shutil.move(src_path, dest_path)
 
-            print(f'refreshing font cache... ', end='', flush=True)
+            print(f'Refreshing font cache… ', end='', flush=True)
 
             # Update the font cache
             subprocess.run(['fc-cache', '-f', '-v'],

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -180,7 +180,12 @@ def dot_Xmodmap_warning():
     xmodmap_file_path = os.path.realpath(os.path.join(os.path.expanduser('~'), '.Xmodmap'))
     if os.path.isfile(xmodmap_file_path):
         print(f'\n{cnfg.separator}')
-        print(f"\t WARNING: You have an '.Xmodmap' file in your home folder!!! \n")
+        if os.environ['COLORTERM']:
+            # Terminal supports ANSI escape sequences
+            print("\033[1;31m\t WARNING: You have an '.Xmodmap' file in your home folder!!!\033[0m")
+        else:
+            # Terminal might not support ANSI escape sequences
+            print(f"\t WARNING: You have an '.Xmodmap' file in your home folder!!! \n")
         print(f'   This can cause confusing PROBLEMS if you are remapping any modifier keys!')
         print(f'{cnfg.separator}\n')
         

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -849,14 +849,14 @@ def apply_desktop_tweaks():
     # General (not DE specific) "fancy pants" additions:
     if cnfg.fancy_pants:
         
-        print(f'Installing font... ', end='')
+        print(f'Installing font... ', end='', flush=True)
 
         # install Fantasque Sans Mono NoLig (no ligatures) from GitHub fork
         font_file   = 'FantasqueSansMono-LargeLineHeight-NoLoopK-NameSuffix.zip'
         font_url    = 'https://github.com/spinda/fantasque-sans-ligatures/releases/download/v1.8.1'
         font_link   = f'{font_url}/{font_file}'
 
-        print(f'downloading... ', end='')
+        print(f'downloading... ', end='', flush=True)
 
         if shutil.which('curl'):
             subprocess.run(['curl', '-LO', font_link], 
@@ -873,7 +873,7 @@ def apply_desktop_tweaks():
             folder_name = font_file.rsplit('.', 1)[0]
             extract_dir = '/tmp/'
 
-            print(f'unzipping... ', end='')
+            print(f'unzipping... ', end='', flush=True)
 
             # Open the zip file and check if it has a top-level directory
             with zipfile.ZipFile(zip_path, 'r') as zip_ref:
@@ -893,7 +893,7 @@ def apply_desktop_tweaks():
 
             os.makedirs(local_fonts_dir, exist_ok=True)
 
-            print(f'moving... ', end='')
+            print(f'moving... ', end='', flush=True)
 
             for file in os.listdir(font_dir):
                 if file.endswith('.ttf'):
@@ -901,12 +901,12 @@ def apply_desktop_tweaks():
                     dest_path = os.path.join(local_fonts_dir, file)
                     shutil.move(src_path, dest_path)
 
-            print(f'refreshing font cache... ', end='')
+            print(f'refreshing font cache... ', end='', flush=True)
 
             # Update the font cache
             subprocess.run(['fc-cache', '-f', '-v'],
                             stdout=DEVNULL, stderr=DEVNULL)
-            print(f'Done.')
+            print(f'Done.', flush=True)
 
             print(f'Installed font: {folder_name}')
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -34,7 +34,7 @@ def signal_handler(sig, frame):
     if sig in (signal.SIGINT, signal.SIGQUIT):
         # Perform any cleanup code here before exiting
         # traceback.print_stack(frame)
-        print(f'\nSIGINT or SIGQUIT received. Exiting.\n')
+        print(f'\n\nSIGINT or SIGQUIT received. Exiting.\n')
         sys.exit(0)
 
 if platform.system() != 'Windows':
@@ -1163,6 +1163,8 @@ def handle_cli_arguments():
 def main(cnfg: InstallerSettings):
     """Main installer function to call specific functions in proper sequence"""
 
+    dot_Xmodmap_warning()
+
     get_environment_info()
 
     valid_distro_names = get_distro_names()
@@ -1170,8 +1172,6 @@ def main(cnfg: InstallerSettings):
         print(f"\nInstaller does not know how to deal with distro '{cnfg.DISTRO_NAME}'\n")
         print(f'Maybe try one of these with "--override-distro" option:\n\t{valid_distro_names}')
         sys.exit(1)
-
-    dot_Xmodmap_warning()
 
     elevate_privileges()
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1087,8 +1087,7 @@ def main(cnfg: InstallerSettings):
                 '>>> ALERT: Permissions changed. You MUST reboot for Toshy to work.\n'
                 f'{cnfg.separator}\n'
         )
-
-    if not cnfg.should_reboot:
+    else:
         # Try to start the tray icon immediately, if reboot is not indicated
         # tray_command        = ['gtk-launch', 'Toshy_Tray']
         tray_icon_cmd = [os.path.join(cnfg.home_dir_path, '.local', 'bin', 'toshy-tray')]

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1071,8 +1071,8 @@ def main(cnfg: InstallerSettings):
             print("AppIndicator extension is enabled. Tray icon should work.")
             # pass
         else:
-            print(f"RECOMMENDATION: Install AppIndicator GNOME extension\n"
-                "Easiest method: 'flatpak install extensionmanager', search for 'appindicator'")
+            print(f"\nRECOMMENDATION: Install AppIndicator GNOME extension\n"
+                "Easiest method: 'flatpak install extensionmanager', search for 'appindicator'\n")
 
     if cnfg.should_reboot or os.path.exists(cnfg.reboot_tmp_file):
         cnfg.should_reboot = True
@@ -1088,10 +1088,6 @@ def main(cnfg: InstallerSettings):
                 f'{cnfg.separator}\n'
         )
 
-    if cnfg.remind_extensions or (cnfg.DESKTOP_ENV == 'gnome' and cnfg.SESSION_TYPE == 'wayland'):
-        print(f'MUST INSTALL GNOME EXTENSIONS IF USING WAYLAND SESSION. See README.')
-        
-
     if not cnfg.should_reboot:
         # Try to start the tray icon immediately, if reboot is not indicated
         # tray_command        = ['gtk-launch', 'Toshy_Tray']
@@ -1106,6 +1102,9 @@ def main(cnfg: InstallerSettings):
         )
         if cnfg.SESSION_TYPE == 'wayland' and cnfg.DESKTOP_ENV == 'kde':
             print(f'SWITCH TO A DIFFERENT WINDOW ONCE TO GET KWIN SCRIPT TO START WORKING!')
+
+    if cnfg.remind_extensions or (cnfg.DESKTOP_ENV == 'gnome' and cnfg.SESSION_TYPE == 'wayland'):
+        print(f'You MUST install GNOME EXTENSIONS if using WAYLAND SESSION. See README.')
 
     print('')   # blank line to avoid crowding the prompt after install is done
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-from re import sub
 import sys
 import pwd
 import grp
@@ -20,6 +19,8 @@ from typing import Dict
 import lib.env as env
 from lib.logger import debug, error
 
+# set a standard path for commands to avoid issues with user customized paths
+os.environ['PATH'] = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 
 if os.name == 'posix' and os.geteuid() == 0:
     print("This app should not be run as root/superuser.")

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -176,18 +176,22 @@ def dot_Xmodmap_warning():
     """Check for '.Xmodmap' file in user's home folder, show warning about mod key remaps"""
     xmodmap_file_path = os.path.realpath(os.path.join(os.path.expanduser('~'), '.Xmodmap'))
     if os.path.isfile(xmodmap_file_path):
-        print(f"\n\t WARNING: You have an '.Xmodmap' file in your home folder!")
-        print(f'This can cause confusing PROBLEMS if you are remapping any modifier keys!\n')
+        print(f'\n{cnfg.separator}')
+        print(f"\t WARNING: You have an '.Xmodmap' file in your home folder!!! \n")
+        print(f' This can cause confusing PROBLEMS if you are remapping any modifier keys!')
+        print(f'{cnfg.separator}\n')
         
         secret_code = ''.join(random.choice(string.ascii_letters) for _ in range(4))
         
-        response = input(f"Do you take responsibility for the issues an '.Xmodmap' file may cause?"
-                        f"\n\t If you understand, enter the secret code '{secret_code}': ")
+        response = input(
+            f"You must take responsibility for the issues an '.Xmodmap' file may cause."
+            f"\n\n\t If you understand, enter the secret code '{secret_code}': "
+        )
         
         if response == secret_code:
-            print("Good code. User has taken responsibility for '.Xmodmap' file. Proceeding...")
+            print(f"\nGood code. User has taken responsibility for '.Xmodmap' file. Proceeding...\n")
         else:
-            print("Code does not match! Try the installer again after dealing with '.Xmodmap'.")
+            print(f"\nCode does not match! Try the installer again after dealing with '.Xmodmap'.\n")
             sys.exit(1)
 
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1224,7 +1224,7 @@ def main(cnfg: InstallerSettings):
         print(  f'\n\n'
                 f'{cnfg.separator}\n'
                 f'{cnfg.reboot_ascii_art}'
-                f'{cnfg.separator}\n\n'
+                f'{cnfg.separator}\n'
                 f'Toshy install complete. Report issues on the GitHub repo.\n'
                 '>>> ALERT: Permissions changed. You MUST reboot for Toshy to work.\n'
                 f'{cnfg.separator}\n'
@@ -1236,7 +1236,7 @@ def main(cnfg: InstallerSettings):
         # Try to launch the tray icon in a separate process not linked to current shell
         # Also, suppress output that might confuse the user
         subprocess.Popen(tray_icon_cmd, close_fds=True, stdout=DEVNULL, stderr=DEVNULL)
-        print(  f'\n\n{cnfg.separator}\n\n'
+        print(  f'\n\n{cnfg.separator}\n'
                 f'Toshy install complete. Report issues on the GitHub repo.\n'
                 f'Rebooting should not be necessary.\n'
                 f'{cnfg.separator}\n'

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -739,6 +739,7 @@ def apply_tweaks_GNOME():
     cmd_path = 'org.gnome.Terminal.Legacy.Keybindings:/org/gnome/terminal/legacy/keybindings/'
     prefs_binding = '<Control>less'
     subprocess.run(['gsettings', 'set', cmd_path, 'preferences', prefs_binding])
+    print(f'Set a keybinding for GNOME Terminal preferences.')
     
     # Enable "Expandable folders" in Nautilus
     # dconf write /org/gnome/nautilus/list-view/use-tree-view true


### PR DESCRIPTION
This PR contains several enhancements and bug fixes. 

- ENV: Avoid process list check unless desktop environment is unidentified by other checks
- Installer: Lots of logging output fixes/enhancements
- Some new windows to match Cmd+W dialog fixes
- Warn about `~/.Xmodmap` existing (could interfere with modifier remapping)
- Implement necessary changes to retain user customizations of config file
- Copy existing preferences database file when running installer
