### PR TITLE
Uninstall function, general retuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,10 @@ This is a list of Linux distributions and desktop variants I've been able to tes
 
 ### Red Hat and similar distros
 
-- Fedora 36/[37*]/38 (from Red Hat)
+- Fedora 36/37/38 (from Red Hat)
 
     - Standard GNOME variant tested (Wayland session requires extensions)
     - KDE variant tested (X11/Xorg or Wayland+KDE session)
-    - Fedora 37 not directly tested, but should work since F36/F38 work
 
 - Ultramarine Linux 38 (Fedora-based)
 
@@ -250,25 +249,27 @@ This is a list of Linux distributions and desktop variants I've been able to tes
 
 - openSUSE Tumbleweed (rolling release)
 
-    - GNOME desktop works (Wayland session needs shell extensions, see Requirements)
+    - GNOME desktop works (Wayland session needs extensions, see Requirements)
     - KDE desktop works (X11/Xorg or Wayland)
     - Other desktop choices should work, if session is X11/Xorg
 
-- openSUSE Leap is currently UNSUPPORTED
+- openSUSE Leap 15.4/15.5 (fixed release) **_UNSUPPORTED!_**
 
-    - Leap still comes with Python version 3.6.x
-    - Current Python version on most distros is 3.9/3.10/3.11
+    - Leap 15.4/15.5 system Python version is 3.6.x
+    - Package list for Tumbleweed doesn't work for Leap
 
 ### Ubuntu variants and Ubuntu-based distros
 
 - Ubuntu official variants tested:
 
-    - Ubuntu 22.04/23.04
-    - Xubuntu 23.04
+    - Ubuntu 22.04/23.04 (X11/Xorg or Wayland+GNOME, requires extensions)
     - Kubuntu 22.04/23.04 (X11/Xorg or Wayland+KDE)
-    - Lubuntu 23.04
+    - Xubuntu 23.04 (X11/Xorg only)
+    - Lubuntu 23.04 (X11/Xorg only)
 
 - Pop!_OS 22.04 LTS (Ubuntu-based)
+
+    - X11/Xorg or Wayland+GNOME (requires extensions)
 
 - KDE Neon (based on Ubuntu LTS releases)
 

--- a/scripts/bin/toshy-config-stop.sh
+++ b/scripts/bin/toshy-config-stop.sh
@@ -19,3 +19,4 @@ echo -e "Stopping Toshy manual config script...\n"
 
 pkill -f "/bin/keyszer"
 pkill -f "toshy-config-start"
+pkill -f "toshy_config"

--- a/scripts/toshy-desktopapps-remove.sh
+++ b/scripts/toshy-desktopapps-remove.sh
@@ -18,14 +18,14 @@ fi
 
 
 
-echo -e "\nRemoving Toshy GUI and Tray app launchers..."
+echo -e "\nRemoving Toshy Preferences and Tray Icon app launchers..."
 
 /usr/bin/rm -f "$HOME/.local/share/applications/Toshy_GUI.desktop"
 /usr/bin/rm -f "$HOME/.local/share/applications/Toshy_Tray.desktop"
 /usr/bin/rm -f "$HOME/.local/share/icons/toshy_app_icon_rainbow.svg"
 
 echo ""
-echo "Finished removing Toshy GUI and Tray app launchers:"
+echo "Finished removing Toshy Preferences and Tray Icon app launchers:"
 echo ""
 echo "- Toshy_GUI.desktop"
 echo "- Toshy_Tray.desktop"

--- a/scripts/toshy-desktopapps-setup.sh
+++ b/scripts/toshy-desktopapps-setup.sh
@@ -20,7 +20,7 @@ LOCAL_SHARE="$HOME/.local/share"
 TOSHY_CFG="$HOME/.config/toshy"
 
 
-echo -e "\nInstalling Toshy GUI and Tray app launchers..."
+echo -e "\nInstalling Toshy Preferences and Tray Icon app launchers..."
 
 mkdir -p "$LOCAL_SHARE/applications"
 mkdir -p "$LOCAL_SHARE/icons"
@@ -30,7 +30,7 @@ cp -f "$TOSHY_CFG/desktop/Toshy_Tray.desktop"           "$LOCAL_SHARE/applicatio
 cp -f "$TOSHY_CFG/assets/toshy_app_icon_rainbow.svg"    "$LOCAL_SHARE/icons"
 
 
-echo -e "\nFinished installing Toshy GUI and Tray app launchers:"
+echo -e "\nFinished installing Toshy Preferences and Tray Icon app launchers:"
 echo ""
 echo "- Toshy Preferences"
 echo "- Toshy Tray Icon"

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1277,6 +1277,9 @@ def uninstall_toshy():
     print()
     print(cnfg.separator)
     print(f'Toshy uninstall complete. Reboot should not be necessary.')
+    print(f"The '~/.config/toshy' folder with your settings has NOT been removed.")
+    print(f'Please report any problems or leftover files on the GitHub repo:')
+    print(f'https://github.com/RedBearAK/toshy')
     print(cnfg.separator)
     print()
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1186,11 +1186,13 @@ def uninstall_toshy():
     remove_desktop_tweaks()
     
     # stop Toshy manual script if it is running
-    subprocess.run(['toshy-config-stop'])
+    toshy_cfg_stop_cmd = os.path.join(home_local_bin, 'toshy-config-stop')
+    subprocess.run([toshy_cfg_stop_cmd])
     
     if cnfg.systemctl_present and cnfg.init_system == 'systemd':
         # stop Toshy systemd services if they are running
-        subprocess.run(['toshy-services-stop'])
+        toshy_svcs_stop_cmd = os.path.join(home_local_bin, 'toshy-services-stop')
+        subprocess.run([toshy_svcs_stop_cmd])
         # run the systemd-remove script
         sysd_rm_cmd = os.path.join(cnfg.toshy_dir_path, 'scripts', 'bin', 'toshy-systemd-remove.sh')
         subprocess.run([sysd_rm_cmd])

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -914,9 +914,10 @@ def setup_kde_dbus_service():
 def setup_systemd_services():
     """Invoke the systemd setup script to install the systemd service units"""
     print(f'\n\n§  Setting up the Toshy systemd services...\n{cnfg.separator}')
-    if cnfg.systemctl_present:
+    if cnfg.systemctl_present and cnfg.init_system == 'systemd':
         script_path = os.path.join(cnfg.toshy_dir_path, 'scripts', 'bin', 'toshy-systemd-setup.sh')
         subprocess.run([script_path])
+        print(f'Finished setting up Toshy "systemd" services.')
     else:
         print(f'System does not seem to be using "systemd"')
 
@@ -1180,10 +1181,13 @@ def uninstall_toshy():
     
     get_environment_info()
     
+    # stop toshy services and/or manual script if it is running
+    
+    
     remove_desktop_tweaks()
     
     # run the systemd-remove script
-    if cnfg.systemctl_present:
+    if cnfg.systemctl_present and cnfg.init_system == 'systemd':
         sysd_rm_cmd = os.path.join(cnfg.toshy_dir_path, 'scripts', 'bin', 'toshy-systemd-remove.sh')
         subprocess.run([sysd_rm_cmd])
     else:

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1174,6 +1174,8 @@ def remove_desktop_tweaks():
 
     if cnfg.DESKTOP_ENV == 'kde':
         remove_tweaks_KDE()
+        
+    print('Removed known desktop tweaks applied by installer.')
 
 
 def uninstall_toshy():
@@ -1181,13 +1183,15 @@ def uninstall_toshy():
     
     get_environment_info()
     
-    # stop toshy services and/or manual script if it is running
-    
-    
     remove_desktop_tweaks()
     
-    # run the systemd-remove script
+    # stop Toshy manual script if it is running
+    subprocess.run(['toshy-config-stop'])
+    
     if cnfg.systemctl_present and cnfg.init_system == 'systemd':
+        # stop Toshy systemd services if they are running
+        subprocess.run(['toshy-services-stop'])
+        # run the systemd-remove script
         sysd_rm_cmd = os.path.join(cnfg.toshy_dir_path, 'scripts', 'bin', 'toshy-systemd-remove.sh')
         subprocess.run([sysd_rm_cmd])
     else:

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -339,12 +339,11 @@ def load_uinput_module():
 def reload_udev_rules():
     try:
         call_attention_to_password_prompt()
-        subprocess.run(
-            "sudo udevadm control --reload-rules && sudo udevadm trigger",
-            shell=True, check=True)
-        print('"udev" rules reloaded successfully.')
+        subprocess.run(['sudo', 'udevadm', 'control', '--reload-rules'], check=True)
+        subprocess.run(['sudo', 'udevadm', 'trigger'], check=True)
+        print('Reloaded the "udev" rules successfully.')
     except subprocess.CalledProcessError as proc_error:
-        print(f'Failed to reload "udev" rules: {proc_error}')
+        print(f'Failed to reload "udev" rules:\n\t{proc_error}')
         prompt_for_reboot()
 
 
@@ -1268,18 +1267,14 @@ def uninstall_toshy():
         except subprocess.CalledProcessError as proc_err:
             error(f'Problem removing Toshy udev rules file:\n\t{proc_err}')
         # refresh the active 'udev' rules
-        try:
-            subprocess.run(['sudo', 'udevadm', 'control', '--reload-rules'], check=True)
-            subprocess.run(['sudo', 'udevadm', 'trigger'], check=True)
-        except subprocess.CalledProcessError as proc_err:
-            error(f'Problem refreshing udev rules:\n\t{proc_err}')
+        reload_udev_rules()
 
     print()
     print(cnfg.separator)
-    print(f'Toshy uninstall complete. Reboot should not be necessary.')
+    print(f'Toshy uninstall complete. Reboot if indicated above with ASCII banner.')
     print(f"The '~/.config/toshy' folder with your settings has NOT been removed.")
-    print(f'Please report any problems or leftover files on the GitHub repo:')
-    print(f'https://github.com/RedBearAK/toshy')
+    print(f'Please report any problems or leftover files/commands on the GitHub repo:')
+    print(f'https://github.com/RedBearAK/toshy/issues/')
     print(cnfg.separator)
     print()
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1273,6 +1273,7 @@ def uninstall_toshy():
         reload_udev_rules()
 
     print()
+    print()
     print(cnfg.separator)
     print(f'Toshy uninstall complete. Reboot if indicated above with ASCII banner.')
     print(f"The '~/.config/toshy' folder with your settings has NOT been removed.")
@@ -1428,6 +1429,8 @@ def main(cnfg: InstallerSettings):
         if not os.path.exists(cnfg.reboot_tmp_file):
             os.mknod(cnfg.reboot_tmp_file)
         print()
+        print()
+        print()
         print(cnfg.separator)
         print(cnfg.separator)
         print(cnfg.reboot_ascii_art)
@@ -1446,6 +1449,8 @@ def main(cnfg: InstallerSettings):
         # Try to launch the tray icon in a separate process not linked to current shell
         # Also, suppress output that might confuse the user
         subprocess.Popen(tray_icon_cmd, close_fds=True, stdout=DEVNULL, stderr=DEVNULL)
+        print()
+        print()
         print()
         print(cnfg.separator)
         print(cnfg.separator)

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -198,7 +198,7 @@ def call_attention_to_password_prompt():
     except subprocess.CalledProcessError:
         # sudo requires a password
         print()
-        print('  -- PASSWORD REQUIRED TO CONTINUE WITH INSTALL --  ')
+        print('  -- PASSWORD REQUIRED TO CONTINUE --  ')
         print()
 
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1223,6 +1223,15 @@ def uninstall_toshy():
         subprocess.run(stop_tray_cmd, check=True)
     except subprocess.CalledProcessError as proc_err:
         print(f'Problem stopping the tray icon process:\n\t{proc_err}')
+    # remove the tray icon autostart file
+    tray_autostart_file = os.path.join(autostart_dir_path, 'Toshy_Tray.desktop')
+
+    tray_autostart_rm_cmd = ['rm', '-f', tray_autostart_file]
+    try:
+        # do not pass as list (brackets) since it is already a list
+        subprocess.run(tray_autostart_rm_cmd, check=True)
+    except subprocess.CalledProcessError as proc_err:
+        error(f'Problem removing Toshy tray icon autostart:\n\t{proc_err}')
 
     # run the desktopapps-remove script
     apps_rm_cmd = os.path.join(cnfg.toshy_dir_path, 'scripts', 'toshy-desktopapps-remove.sh')

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -299,7 +299,7 @@ def load_uinput_module():
 
     try:
         subprocess.check_output("lsmod | grep uinput", shell=True)
-        print('The "uinput" module is already loaded')
+        print('The "uinput" module is already loaded.')
     except subprocess.CalledProcessError:
         print('The "uinput" module is not loaded, loading now...')
         call_attention_to_password_prompt()
@@ -360,13 +360,16 @@ def install_udev_rules():
         command = f'sudo tee {rules_file_path}'
         try:
             call_attention_to_password_prompt()
+            print(f'Using these "udev" rules for "uinput" device: ')
+            print()
             subprocess.run(command, input=rule_content.encode(), shell=True, check=True)
-            print(f'"udev" rules file successfully installed.')
+            print()
+            print(f'Toshy "udev" rules file successfully installed.')
             reload_udev_rules()
         except subprocess.CalledProcessError as proc_error:
             print()
             error(f'ERROR: Problem while installing "udev" rules file for keymapper.\n')
-            err_output: bytes = proc_error.output  # Type hinting the error_output variable
+            err_output: bytes = proc_error.output  # Type hinting the error output variable
             # Deal with possible 'NoneType' error output
             error(f'Command output:\n{err_output.decode() if err_output else "No error output"}')
             print()
@@ -390,7 +393,7 @@ def verify_user_groups():
         except subprocess.CalledProcessError as proc_error:
             print()
             error(f'ERROR: Problem when trying to create "input" group.\n')
-            err_output: bytes = proc_error.output  # Type hinting the error_output variable
+            err_output: bytes = proc_error.output  # Type hinting the error output variable
             # Deal with possible 'NoneType' error output
             error(f'Command output:\n{err_output.decode() if err_output else "No error output"}')
             print()
@@ -412,7 +415,7 @@ def verify_user_groups():
             print()
             error(f'ERROR: Problem when trying to add user "{cnfg.user_name}" to '
                     f'group "{cnfg.input_group_name}".\n')
-            err_output: bytes = proc_error.output  # Type hinting the error_output variable
+            err_output: bytes = proc_error.output  # Type hinting the error output variable
             # Deal with possible 'NoneType' error output
             error(f'Command output:\n{err_output.decode() if err_output else "No error output"}')
             print()
@@ -795,8 +798,8 @@ def install_pip_packages():
 
 
 def install_bin_commands():
-    """Install the convenient scripts to manage Toshy"""
-    print(f'\n\n§  Installing Toshy script commands...\n{cnfg.separator}')
+    """Install the convenient terminal commands (symlinks to scripts) to manage Toshy"""
+    print(f'\n\n§  Installing Toshy terminal commands...\n{cnfg.separator}')
     script_path = os.path.join(cnfg.toshy_dir_path, 'scripts', 'toshy-bincommands-setup.sh')
     subprocess.run([script_path])
 
@@ -918,12 +921,12 @@ def setup_systemd_services():
         subprocess.run([script_path])
         print(f'Finished setting up Toshy "systemd" services.')
     else:
-        print(f'System does not seem to be using "systemd"')
+        print(f'System does not seem to be using "systemd" as init system.')
 
 
 def autostart_tray_icon():
     """Set up the tray icon to autostart at login"""
-    print(f'\n\n§  Setting tray icon to load automatically at login...\n{cnfg.separator}')
+    print(f'\n\n§  Setting up tray icon to load automatically at login...\n{cnfg.separator}')
     user_path           = os.path.expanduser('~')
     desktop_files_path  = os.path.join(user_path, '.local', 'share', 'applications')
     tray_desktop_file   = os.path.join(desktop_files_path, 'Toshy_Tray.desktop')
@@ -938,7 +941,7 @@ def autostart_tray_icon():
         sys.exit(1)
     subprocess.run(['ln', '-sf', tray_desktop_file, dest_link_file])
 
-    print(f'Tray icon should appear in system tray at each login.')
+    print(f'Toshy tray icon should appear in system tray at each login.')
 
 ###################################################################################################
 ##  TWEAKS UTILITY FUNCTIONS - START
@@ -1155,7 +1158,7 @@ def apply_desktop_tweaks():
                             stdout=DEVNULL, stderr=DEVNULL)
             print(f'Done.', flush=True)
 
-            print(f'Installed font: {folder_name}')
+            print(f"Installed font: '{folder_name}'")
 
     if not cnfg.tweak_applied:
         print(f'If nothing printed, no tweaks available for "{cnfg.DESKTOP_ENV}" yet.')
@@ -1424,14 +1427,18 @@ def main(cnfg: InstallerSettings):
         # create reboot reminder temp file, in case installer is run again
         if not os.path.exists(cnfg.reboot_tmp_file):
             os.mknod(cnfg.reboot_tmp_file)
-        print(  f'\n\n'
-                f'{cnfg.separator}\n'
-                f'{cnfg.reboot_ascii_art}'
-                f'{cnfg.separator}\n'
-                f'Toshy install complete. Report issues on the GitHub repo.\n'
-                '>>> ALERT: Permissions changed. You MUST reboot for Toshy to work.\n'
-                f'{cnfg.separator}\n'
-        )
+        print()
+        print(cnfg.separator)
+        print(cnfg.separator)
+        print(cnfg.reboot_ascii_art)
+        print(cnfg.separator)
+        print(cnfg.separator)
+        print('Toshy install complete. Report issues on the GitHub repo.')
+        print('https://github.com/RedBearAK/toshy/issues/')
+        print('>>>  ALERT: Permissions changed. You MUST reboot for Toshy to work.')
+        print(cnfg.separator)
+        print(cnfg.separator)
+        print()
     else:
         # Try to start the tray icon immediately, if reboot is not indicated
         # tray_command        = ['gtk-launch', 'Toshy_Tray']
@@ -1439,11 +1446,15 @@ def main(cnfg: InstallerSettings):
         # Try to launch the tray icon in a separate process not linked to current shell
         # Also, suppress output that might confuse the user
         subprocess.Popen(tray_icon_cmd, close_fds=True, stdout=DEVNULL, stderr=DEVNULL)
-        print(  f'\n\n{cnfg.separator}\n'
-                f'Toshy install complete. Report issues on the GitHub repo.\n'
-                f'Rebooting should not be necessary.\n'
-                f'{cnfg.separator}\n'
-        )
+        print()
+        print(cnfg.separator)
+        print(cnfg.separator)
+        print('Toshy install complete. Rebooting should not be necessary.')
+        print('Report issues on the GitHub repo.')
+        print('https://github.com/RedBearAK/toshy/issues/')
+        print(cnfg.separator)
+        print(cnfg.separator)
+        print()
         if cnfg.SESSION_TYPE == 'wayland' and cnfg.DESKTOP_ENV == 'kde':
             print(f'Switch to a different window ONCE to get KWin script to start working!')
 

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -16,10 +16,10 @@ import fcntl
 import psutil
 import shutil
 import signal
-import select
 import threading
-import traceback
+# import traceback
 import subprocess
+from subprocess import DEVNULL
 
 # Local imports
 from lib.logger import *
@@ -464,15 +464,13 @@ def fn_stop_toshy_services(widget):
 
 def fn_restart_toshy_script(widget):
     """Start the manual run config script"""
-    subprocess.Popen(   ['/bin/sh', '-c', 'env toshy-config-restart'],
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE)
+    toshy_cfg_restart_cmd = os.path.join(home_local_bin, 'toshy-config-restart')
+    subprocess.Popen([toshy_cfg_restart_cmd], stdout=DEVNULL, stderr=DEVNULL)
 
 def fn_stop_toshy_script(widget):
     """Stop the manual run config script"""
-    subprocess.Popen(   ['/bin/sh', '-c', 'env toshy-config-stop'],
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE)
+    toshy_cfg_stop_cmd = os.path.join(home_local_bin, 'toshy-config-stop')
+    subprocess.Popen([toshy_cfg_stop_cmd], stdout=DEVNULL, stderr=DEVNULL)
 
 def fn_open_preferences(widget):
     subprocess.Popen(['toshy-gui'])


### PR DESCRIPTION
Changes:

- README updates
- Stop manual script more reliably
- Tuning of installer script output
- Implementation of '--uninstall' CLI option for 'toshy_setup.py' installer
- Fix stopping/restarting the manual script from tray icon menu
