### PR TITLE
Typos in README, tray icon labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Current status: Stable-ish Beta (Please Read)
 
-WARNING: There is a veru annoying "bug" going around where there is a problem with the `xdg-desktop-portal` and `xdg-desktop-portal-gnome` services causing problems with launching certain applications (particularly GTK apps like Firefox, but also reportedly Qt apps sometimes) in a Wayland session. Some distros seem to have a fix for this, others have not fixed it yet.  
+WARNING: There is a very annoying "bug" going around where there is a problem with the `xdg-desktop-portal` and `xdg-desktop-portal-gnome` services causing very long delays with launching certain applications (particularly GTK apps like Firefox, but also reportedly Qt apps sometimes) in a Wayland session. Some distros seem to have a fix for this, others have not fixed it yet.  
 
-Symptoms for Toshy are that the systemd services can't start up properly until anywhere from 30 seconds to a minute or more after logging in. They will eventually start, and restarting the services later works without issue. I've been observing this on KDE in multiple Linux distros. One "fix" is to mask the `xdg-desktop-portal-gnome` service to keep it from clogging things up:  
+Symptoms for Toshy are that the systemd services can't start up properly until anywhere from 30 seconds to a minute or more after logging in. They will eventually start, and restarting the services later, after the glitchy desktop portal service times out, works without issue. I've been observing this on KDE in multiple Linux distros. One "fix" is to mask the `xdg-desktop-portal-gnome` service to keep it from clogging things up:  
 
 ```
 systemctl --user mask xdg-desktop-portal-gnome
 ```
+
+But you may need to unmask it if you log into a GNOME desktop, in a Wayland session.  
 
 ## Main issues you might run into
 

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -371,6 +371,12 @@ def fn_monitor_toshy_services():
             # debug(f'{curr_svcs_state_tup = }\n')
             tray_indicator.set_icon_full(icon_file_grayscale, "Toshy Tray Icon Undefined")
 
+        if curr_svcs_state_tup != last_svcs_state_tup:
+            try:
+                toshy_config_status_item.set_label(f'         Config: {svc_status_config}')
+                session_monitor_status_item.set_label(f'     SessMon: {svc_status_sessmon}')
+            except NameError: pass  # Let it pass if menu item not ready yet
+
         last_svcs_state_tup = curr_svcs_state_tup
 
         time.sleep(2)


### PR DESCRIPTION
Fix typos in README
Update tray icon menu item labels a bit later
