### PR TITLE
CentOS 7, openSUSE Leap 15.5, Mint 21.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,18 @@ As noted elsewhere in the README, there is no Windows version of Toshy, unlike K
     - Red Hat Enterprise Linux itself? Probably.
     - Try `./toshy_setup.py --override-distro=almalinux` or `=rhel`
 
+- CentOS 7 (RHEL 7 clone) - Partial support:
+
+    - You must install `python3` to run `toshy_setup.py`
+    - systemd "user" services are not supported in CentOS/RHEL 7
+    - Auto-start at login with systemd services not available
+    - To manually start Toshy config from tray icon menu:
+        - "(Re)Start Toshy Script" option will start Toshy config
+        - "Stop Toshy Script" option will stop background Toshy config
+    - To manually start Toshy config from terminal:
+        - Use `toshy-config-start` or `toshy-config-verbose-start`
+        - Use `toshy-config-stop` to stop a background Toshy config
+
 ### openSUSE (RPM-based packaging system)
 
 - openSUSE Tumbleweed (rolling release)

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ As noted elsewhere in the README, there is no Windows version of Toshy, unlike K
     - You must install `python3` to run `toshy_setup.py`
     - systemd "user" services are not supported in CentOS/RHEL 7
     - Auto-start at login with systemd services not available
+    - Cmd+Space (Alt+F1) shortcut must be assigned to app launcher menu
     - To manually start Toshy config from tray icon menu:
         - "(Re)Start Toshy Script" option will start Toshy config
         - "Stop Toshy Script" option will stop background Toshy config

--- a/README.md
+++ b/README.md
@@ -302,10 +302,11 @@ As noted elsewhere in the README, there is no Windows version of Toshy, unlike K
     - KDE desktop works (X11/Xorg or Wayland)
     - Other desktop choices should work, if session is X11/Xorg
 
-- openSUSE Leap 15.4/15.5 (fixed release) **_UNSUPPORTED!_**
+- openSUSE Leap 15.5 (fixed release) **_WORKING!_**
 
-    - Leap 15.4/15.5 system Python version is 3.6.x
-    - Package list for Tumbleweed doesn't work for Leap
+    - GNOME desktop works (Wayland session needs extensions, see Requirements)
+    - KDE desktop works (X11/Xorg or Wayland)
+    - Other desktop choices should work, if session is X11/Xorg
 
 ### Ubuntu variants and Ubuntu-based distros
 
@@ -333,7 +334,7 @@ As noted elsewhere in the README, there is no Windows version of Toshy, unlike K
 
 - elementary OS 7.0 (Ubuntu-based)
 
-- Linux Mint 21.1 (Ubuntu-based)
+- Linux Mint 21.1/21.2 (Ubuntu-based)
 
     - Cinnamon desktop
     - Xfce desktop

--- a/toshy-default-config/toshy_config.py
+++ b/toshy-default-config/toshy_config.py
@@ -810,13 +810,16 @@ def matchProps(*,
     def _matchProps(ctx: KeyContext):
         cond_list = []
         if _clas is not None:
-            clas_match = re.search(clas_rgx, ctx.wm_class)
+            clas_match = re.search(clas_rgx,
+                                    ctx.wm_class or 'ERR: matchProps: NoneType in ctx.wm_class')
             cond_list.append(not clas_match if not_clas is not None else clas_match)
         if _name is not None:
-            name_match = re.search(name_rgx, ctx.wm_name)
+            name_match = re.search(name_rgx,
+                                    ctx.wm_name or 'ERR: matchProps: NoneType in ctx.wm_name')
             cond_list.append(not name_match if not_name is not None else name_match)
         if _devn is not None:
-            devn_match = re.search(devn_rgx, ctx.device_name)
+            devn_match = re.search(devn_rgx,
+                                    ctx.device_name or 'ERR: matchProps: NoneType in ctx.device_name')
             cond_list.append(not devn_match if not_devn is not None else devn_match)
         # these two MUST check explicitly for "is not None" because external input is True/False,
         # and we want to be able to match the LED_on state of either "True" or "False"

--- a/toshy-default-config/toshy_config.py
+++ b/toshy-default-config/toshy_config.py
@@ -277,7 +277,7 @@ terminals_lod = [
     {clas:"^lxterminal$"                },
     {clas:"^mate-terminal$"             },
     {clas:"^org.gnome.Console$"         },
-    {clas:"org.kde.konsole$"            },
+    {clas:"^org.kde.konsole$"           },
     {clas:"^roxterm$"                   },
     {clas:"^qterminal$"                 },
     {clas:"^st$"                        },
@@ -3530,10 +3530,13 @@ keymap("Tab Nav fix for apps that use Ctrl+Alt+PgUp/PgDn", {
 
 keymap("Konsole tab switching", {
     # Ctrl Tab - In App Tab Switching
-    C("LC-Tab") :               C("Shift-Right"),
     C("Shift-LC-Tab") :         C("Shift-Left"),
+    C("LC-Tab") :               C("Shift-Right"),
     C("LC-Grave") :             C("Shift-Left"),
-}, when = matchProps(clas="^konsole$"))
+    # Konsole tab switching in KDE4 (not needed in KDE5)
+    C("Shift-RC-Left_Brace"):   C("Shift-Left"),                # Go to prior tab (Left)
+    C("Shift-RC-Right_Brace"):  C("Shift-Right"),               # Go to next tab (Right)
+}, when = matchProps(clas="^konsole$|^org.kde.Konsole$"))
 
 keymap("Elementary Terminal tab switching", {
     # Ctrl Tab - In App Tab Switching

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -167,6 +167,7 @@ def safe_shutdown(exit_code=0):
 
     # invalidate the sudo ticket, don't leave system in "superuser" state
     subprocess.run(['sudo', '-k'])
+    print()     # avoid crowding the prompt on exit
     sys.exit(exit_code)
 
 
@@ -269,7 +270,7 @@ def dot_Xmodmap_warning():
             info("Good code. User has taken responsibility for '.Xmodmap' file. Proceeding...\n")
         else:
             print()
-            error("Code does not match! Try the installer again after dealing with '.Xmodmap'.\n")
+            error("Code does not match! Try the installer again after dealing with '.Xmodmap'.")
             safe_shutdown(1)
 
 
@@ -283,7 +284,6 @@ def ask_is_distro_updated():
     if response not in ['y', 'Y']:
         print()
         error("Try the installer again after you've done a full system update. Exiting.")
-        print()
         safe_shutdown(1)
 
 
@@ -545,7 +545,7 @@ def install_distro_pkgs():
         print()
         print(f"ERROR: No list of packages found for this distro: '{cnfg.DISTRO_NAME}'")
         print(f'Installation cannot proceed without a list of packages. Sorry.')
-        print(f'Try some options in "./toshy_setup.py --help"\n')
+        print(f'Try some options in "./toshy_setup.py --help"')
         safe_shutdown(1)
 
     cnfg.pkgs_for_distro = pkg_groups_map[pkg_group]
@@ -613,7 +613,7 @@ def install_distro_pkgs():
 
     else:
         print()
-        error(f"ERROR: Installer does not know how to handle distro: {cnfg.DISTRO_NAME}\n")
+        error(f"ERROR: Installer does not know how to handle distro: {cnfg.DISTRO_NAME}")
         safe_shutdown(1)
 
     # Have something come out even if package list is empty (like Arch after initial run)
@@ -1343,7 +1343,7 @@ def uninstall_toshy():
     # confirm if user really wants to uninstall
     response = input("\nThis will completely uninstall Toshy. Are you sure? [y/N]: ")
     if response not in ['y', 'Y']:
-        print(f"\nToshy uninstall cancelled.\n")
+        print(f"\nToshy uninstall cancelled.")
         safe_shutdown()
     else:
         print(f'\nToshy uninstall proceeding...\n')
@@ -1631,7 +1631,7 @@ def main(cnfg: InstallerSettings):
     if cnfg.remind_extensions or (cnfg.DESKTOP_ENV == 'gnome' and cnfg.SESSION_TYPE == 'wayland'):
         print(f'You MUST install GNOME EXTENSIONS if using Wayland+GNOME! See Toshy README.')
 
-    print()   # blank line to avoid crowding the prompt after install is done
+    # print()   # blank line to avoid crowding the prompt after install is done
     safe_shutdown()
 
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -460,23 +460,27 @@ pkg_groups_map = {
     'redhat-based':    ["gcc", "git", "cairo-devel", "cairo-gobject-devel", "dbus-devel",
                         "python3-dbus", "python3-devel", "python3-pip", "python3-tkinter",
                         "gobject-introspection-devel", "libappindicator-gtk3", "xset",
-                        "systemd-devel", "zenity"],
+                        "libnotify", "systemd-devel", "zenity"],
+
     'opensuse-based':  ["gcc", "git", "cairo-devel",  "dbus-1-devel",
                         "python311-tk", "python311-dbus-python-devel", "python-devel",
                         "gobject-introspection-devel", "libappindicator3-devel", "tk",
                         "libnotify-tools", "typelib-1_0-AyatanaAppIndicator3-0_1",
                         "systemd-devel", "zenity"],
+
     'ubuntu-based':    ["curl", "git", "input-utils", "libcairo2-dev", "libnotify-bin",
                         "python3-dbus", "python3-dev", "python3-pip", "python3-venv",
                         "python3-tk", "libdbus-1-dev", "libgirepository1.0-dev",
                         "gir1.2-appindicator3-0.1", "libsystemd-dev", "zenity"],
-    'debian-based':    ["curl", "git", "input-utils", "libcairo2-dev", "libdbus-1-dev",
-                        "python3-dbus", "python3-dev", "python3-venv", "python3-tk",
-                        "libgirepository1.0-dev", "libsystemd-dev", "zenity",
-                        "gir1.2-ayatanaappindicator3-0.1"],
+
+    'debian-based':    ["curl", "git", "input-utils", "libcairo2-dev", "libnotify-bin", 
+                        "python3-dbus", "python3-dev", "python3-pip", "python3-venv",
+                        "python3-tk", "libdbus-1-dev", "libgirepository1.0-dev", 
+                        "gir1.2-ayatanaappindicator3-0.1", "libsystemd-dev", "zenity"],
+
     'arch-based':      ["cairo", "dbus", "evtest", "git", "gobject-introspection", "tk",
                         "libappindicator-gtk3", "pkg-config", "python-dbus", "python-pip",
-                        "python", "systemd", "zenity"],
+                        "python", "libnotify", "systemd", "zenity"],
 }
 
 extra_pkgs_map = {

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1518,8 +1518,9 @@ def handle_cli_arguments():
     }
 
     if sum(exit_args_dct.values()) > 1:
-        raise ValueError(   f"ERROR: These options are mutually exclusive (use only one): "
-                            f"\n\t{', '.join(exit_args_dct.keys())}\n")
+        error(f"ERROR: These options are mutually exclusive (use only one):" +
+            ''.join(f"\n\t{arg}" for arg in exit_args_dct.keys()))
+        safe_shutdown(1)
 
     if args.uninstall:
         uninstall_toshy()

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1512,7 +1512,7 @@ def handle_cli_arguments():
 
     # Check that "exit-after" arguments are used alone
     if any(exit_args_dct.values()) and sum(all_args_dct.values()) > 1:
-        error(f"ERROR: These options should be used alone:" +
+        error(f"ERROR: These options should be used alone:\n" +
             ''.join(f"\n\t{arg}" for arg in exit_args_dct.keys()))
         safe_shutdown(1)
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -593,9 +593,11 @@ def install_distro_pkgs():
                         # sudo yum install -y rh-python38
                         subprocess.run(['sudo', 'yum', 'install', '-y', 'rh-python38'],
                                         check=True)
+                        # THIS WILL DROP US INTO A NEW SHELL! Not what we want. 
                         # scl enable rh-python38 bash
-                        subprocess.run(['scl', 'enable', 'rh-python38', 'bash'],
-                                        check=True)
+                        # subprocess.run(['scl', 'enable', 'rh-python38', 'bash'],
+                        #                 check=True)
+                        cnfg.py_interp_path = '/opt/rh/rh-python38/root/usr/bin/python3.8'
                     except subprocess.CalledProcessError as proc_err:
                         print()
                         error(f'ERROR: (CentOS-specific) Problem installing/enabling Python 3.8:'
@@ -891,11 +893,11 @@ def setup_python_virt_env():
 
     # Create the virtual environment if it doesn't exist
     if not os.path.exists(cnfg.venv_path):
-        # change the Python interpreter path to user current release version 
+        # change the Python interpreter path to use current release version from pkg list
         # if distro is openSUSE Leap type (instead of old 3.6 version)
         if cnfg.DISTRO_NAME in distro_groups_map['leap-based']:
             if shutil.which(f'python{curr_py_rel_ver}'):
-                cnfg.py_interp_path     = shutil.which(f'python{curr_py_rel_ver}')
+                cnfg.py_interp_path = shutil.which(f'python{curr_py_rel_ver}')
                 print(f'Using Python version {curr_py_rel_ver}.')
             else:
                 print(  f'Current stable Python release version '

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1452,7 +1452,8 @@ def handle_cli_arguments():
     """Deal with CLI arguments given to installer script"""
     parser = argparse.ArgumentParser(
         description='Toshy Installer - some options are mutually exclusive',
-        epilog='Default action: Install Toshy'
+        epilog='Default action: Install Toshy',
+        allow_abbrev=False
     )
 
     # Add arguments
@@ -1460,12 +1461,12 @@ def handle_cli_arguments():
         '--override-distro',
         type=str,
         # dest='override_distro',
-        help=f'Override auto-detection of distro name/type. See --list-distros'
+        help=f'Override auto-detection of distro name/type. See "--list-distros"'
     )
     parser.add_argument(
         '--list-distros',
         action='store_true',
-        help='Display list of distro names to use with --override-distro'
+        help='Display list of distro names to use with "--override-distro"'
     )
     parser.add_argument(
         '--uninstall',
@@ -1518,7 +1519,7 @@ def handle_cli_arguments():
 
     if sum(exit_args_dct.values()) > 1:
         raise ValueError(   f"ERROR: These options are mutually exclusive (use only one): "
-                            f"{', '.join(exit_args_dct.keys())}\n")
+                            f"\n\t{', '.join(exit_args_dct.keys())}\n")
 
     if args.uninstall:
         uninstall_toshy()

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -465,7 +465,7 @@ distro_groups_map = {
     #                     "rhel", "almalinux", "rocky", "eurolinux"],
 
     # separate references for RHEL types versus Fedora types
-    'fedora-based':    ["fedora", "fedoralinux", "ultramarine", "nobara"],
+    'fedora-based':    ["fedora", "fedoralinux", "ultramarine", "nobara", "silverblue"],
     'rhel-based':      ["rhel", "almalinux", "rocky", "eurolinux"],
 
     'tumbleweed-based':["opensuse-tumbleweed"],
@@ -573,7 +573,10 @@ def install_distro_pkgs():
             safe_shutdown(1)
 
     if cnfg.DISTRO_NAME in dnf_distros:
-        check_for_pkg_mgr_cmd('dnf')
+        if cnfg.DISTRO_NAME == 'silverblue':
+            check_for_pkg_mgr_cmd('rpm-ostree')
+        else:
+            check_for_pkg_mgr_cmd('dnf')
         # do extra stuff only if distro is a RHEL type (not Fedora type)
         if cnfg.DISTRO_NAME in distro_groups_map['rhel-based']:
             call_attention_to_password_prompt()
@@ -583,7 +586,10 @@ def install_distro_pkgs():
             subprocess.run(['sudo', 'dnf', 'install', '-y', 'epel-release'])
             subprocess.run(['sudo', 'dnf', 'update', '-y'])
         # now do the install of the list of packages
-        subprocess.run(['sudo', 'dnf', 'install', '-y'] + cnfg.pkgs_for_distro)
+        if cnfg.DISTRO_NAME == 'silverblue':
+            subprocess.run(['sudo', 'rpm-ostree', 'install', '-y'] + cnfg.pkgs_for_distro)
+        else:
+            subprocess.run(['sudo', 'dnf', 'install', '-y'] + cnfg.pkgs_for_distro)
 
     elif cnfg.DISTRO_NAME in zypper_distros:
         check_for_pkg_mgr_cmd('zypper')

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -922,9 +922,19 @@ def setup_kwin2dbus_script():
         zipf.write(os.path.join(kwin_script_path, 'metadata.json'), arcname='metadata.json')
 
     # Try to remove any installed KWin script entirely
-    result = subprocess.run(
+    process = subprocess.Popen(
         ['kpackagetool5', '-t', 'KWin/Script', '-r', kwin_script_name],
-        capture_output=True, text=True)
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = process.communicate()
+    out = out.decode('utf-8')
+    err = err.decode('utf-8')
+    result = subprocess.CompletedProcess(args=process.args, returncode=process.returncode,
+                                            stdout=out, stderr=err)
+
+    # NOT COMPATIBLE WITH PYTHON 3.6
+    # result = subprocess.run(
+    #     ['kpackagetool5', '-t', 'KWin/Script', '-r', kwin_script_name],
+    #     capture_output=True, text=True)
 
     if result.returncode != 0:
         pass
@@ -932,8 +942,19 @@ def setup_kwin2dbus_script():
         print("Successfully removed existing KWin script.")
 
     # Install the KWin script
-    result = subprocess.run(
-        ['kpackagetool5', '-t', 'KWin/Script', '-i', script_tmp_file], capture_output=True, text=True)
+    process = subprocess.Popen(
+        ['kpackagetool5', '-t', 'KWin/Script', '-i', script_tmp_file],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = process.communicate()
+    out = out.decode('utf-8')
+    err = err.decode('utf-8')
+    result = subprocess.CompletedProcess(args=process.args, returncode=process.returncode,
+                                            stdout=out, stderr=err)
+
+    # NOT COMPATIBLE WITH PYTHON 3.6
+    # result = subprocess.run(
+    #     ['kpackagetool5', '-t', 'KWin/Script', '-i', script_tmp_file],
+    #     capture_output=True, text=True)
 
     if result.returncode != 0:
         error(f"Error installing the KWin script. The error was:\n\t{result.stderr}")
@@ -946,11 +967,22 @@ def setup_kwin2dbus_script():
     except (FileNotFoundError, PermissionError): pass
 
     # Enable the script using kwriteconfig5
-    result = subprocess.run(
+    process = subprocess.Popen(
         [   'kwriteconfig5', '--file', 'kwinrc', '--group', 'Plugins', '--key',
             f'{kwin_script_name}Enabled', 'true'],
-        capture_output=True, text=True)
-    
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = process.communicate()
+    out = out.decode('utf-8')
+    err = err.decode('utf-8')
+    result = subprocess.CompletedProcess(args=process.args, returncode=process.returncode,
+                                            stdout=out, stderr=err)
+
+    # NOT COMPATIBLE WITH PYTHON 3.6
+    # result = subprocess.run(
+    #     [   'kwriteconfig5', '--file', 'kwinrc', '--group', 'Plugins', '--key',
+    #         f'{kwin_script_name}Enabled', 'true'],
+    #     capture_output=True, text=True)
+
     if result.returncode != 0:
         error(f"Error enabling the KWin script. The error was:\n\t{result.stderr}")
     else:

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -994,7 +994,7 @@ def install_desktop_apps():
 def setup_kwin2dbus_script():
     """Install the KWin script to notify D-Bus service about window focus changes"""
     print(f'\n\n§  Setting up the Toshy KWin script...\n{cnfg.separator}')
-    if not shutil.which('kpackagetool5') or not shutil.which('kconfigwrite5'):
+    if not shutil.which('kpackagetool5') or not shutil.which('kwriteconfig5'):
         pass
         print(f'One or more KDE CLI tools not found. Assuming older KDE...')
         return
@@ -1220,6 +1220,9 @@ def remove_tweaks_GNOME():
 def apply_tweaks_KDE():
     """Utility function to add desktop tweaks to KDE"""
 
+    if not shutil.which('kwriteconfig5'):
+        return
+
     # Documentation on the use of Meta key in KDE:
     # https://userbase.kde.org/Plasma/Tips#Windows.2FMeta_Key
     subprocess.run(['kwriteconfig5', '--file', 'kwinrc', '--group',
@@ -1279,6 +1282,8 @@ def apply_tweaks_KDE():
 
 def remove_tweaks_KDE():
     """Utility function to remove the tweaks applied to KDE"""
+    if not shutil.which('kwriteconfig5'):
+        return
 
     # Re-enable Meta key opening the application menu
     subprocess.run(['kwriteconfig5', '--file', 'kwinrc', '--group',

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -581,8 +581,9 @@ def install_distro_pkgs():
 
             # do even more prep/checks if distro is CentOS
             if cnfg.DISTRO_NAME in ['centos'] and cnfg.DISTRO_VER in ['7', '8']:
-                if py_interp_ver_tup >= curr_py_rel_ver_tup:
-                    print(f"Good, Python version is current stable ({curr_py_rel_ver}) or later: "
+                # if py_interp_ver_tup >= curr_py_rel_ver_tup:
+                if py_interp_ver_tup >= (3, 8):
+                    print(f"Good, Python version is 3.8 or later: "
                             f"'{py_interp_ver}'")
                 else:
                     # sudo yum install -y centos-release-scl
@@ -598,9 +599,9 @@ def install_distro_pkgs():
 
 
                     error(f'ERROR: Python version used to run Toshy installer is too old.')
-                    debug(f"Install stable Python release version {curr_py_rel_ver} or later.")
+                    debug(f"Install stable Python release version 3.8 or later.")
                     debug(f'Then run Toshy installer with that version of Python interpreter:')
-                    debug(f"'python{curr_py_rel_ver} ./toshy_setup.py [--option]'")
+                    debug(f"'python3.8 ./toshy_setup.py [--option]'")
                     safe_shutdown(1)
                 # use yum to install dnf package manager
                 check_for_pkg_mgr_cmd('yum')

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -594,6 +594,10 @@ def install_distro_pkgs():
                         # sudo yum install -y rh-python38
                         subprocess.run(['sudo', 'yum', 'install', '-y', 'rh-python38'],
                                         check=True)
+                        # sudo yum install rh-python38-python-devel
+                        subprocess.run(['sudo', 'yum', 'install', '-y', 'rh-python38-python-devel'],
+                                        check=True)
+                        
                         # THIS WILL DROP US INTO A NEW SHELL! Not what we want. 
                         # scl enable rh-python38 bash
                         # subprocess.run(['scl', 'enable', 'rh-python38', 'bash'],
@@ -990,6 +994,11 @@ def install_desktop_apps():
 def setup_kwin2dbus_script():
     """Install the KWin script to notify D-Bus service about window focus changes"""
     print(f'\n\n§  Setting up the Toshy KWin script...\n{cnfg.separator}')
+    if not shutil.which('kpackagetool5') or not shutil.which('kconfigwrite5'):
+        pass
+        print(f'One or more KDE CLI tools not found. Assuming older KDE...')
+        return
+    
     kwin_script_name    = 'toshy-dbus-notifyactivewindow'
     kwin_script_path    = os.path.join( cnfg.toshy_dir_path,
                                         'kde-kwin-dbus-service', kwin_script_name)
@@ -1013,11 +1022,6 @@ def setup_kwin2dbus_script():
     result = subprocess.CompletedProcess(args=process.args, returncode=process.returncode,
                                             stdout=out, stderr=err)
 
-    # NOT COMPATIBLE WITH PYTHON 3.6
-    # result = subprocess.run(
-    #     ['kpackagetool5', '-t', 'KWin/Script', '-r', kwin_script_name],
-    #     capture_output=True, text=True)
-
     if result.returncode != 0:
         pass
     else:
@@ -1032,11 +1036,6 @@ def setup_kwin2dbus_script():
     err = err.decode('utf-8')
     result = subprocess.CompletedProcess(args=process.args, returncode=process.returncode,
                                             stdout=out, stderr=err)
-
-    # NOT COMPATIBLE WITH PYTHON 3.6
-    # result = subprocess.run(
-    #     ['kpackagetool5', '-t', 'KWin/Script', '-i', script_tmp_file],
-    #     capture_output=True, text=True)
 
     if result.returncode != 0:
         error(f"Error installing the KWin script. The error was:\n\t{result.stderr}")
@@ -1058,12 +1057,6 @@ def setup_kwin2dbus_script():
     err = err.decode('utf-8')
     result = subprocess.CompletedProcess(args=process.args, returncode=process.returncode,
                                             stdout=out, stderr=err)
-
-    # NOT COMPATIBLE WITH PYTHON 3.6
-    # result = subprocess.run(
-    #     [   'kwriteconfig5', '--file', 'kwinrc', '--group', 'Plugins', '--key',
-    #         f'{kwin_script_name}Enabled', 'true'],
-    #     capture_output=True, text=True)
 
     if result.returncode != 0:
         error(f"Error enabling the KWin script. The error was:\n\t{result.stderr}")

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -586,23 +586,21 @@ def install_distro_pkgs():
                     print(f"Good, Python version is 3.8 or later: "
                             f"'{py_interp_ver}'")
                 else:
-                    # sudo yum install -y centos-release-scl
-                    # sudo yum install -y rh-python38
-                    # scl enable rh-python38 bash
-                    
-                    # OR:
-                    
-                    # sudo yum install -y epel-release
-                    # sudo yum install -y https://repo.ius.io/ius-release-el7.rpm
-                    # sudo yum update
-                    # sudo yum install -y python311
-
-
-                    error(f'ERROR: Python version used to run Toshy installer is too old.')
-                    debug(f"Install stable Python release version 3.8 or later.")
-                    debug(f'Then run Toshy installer with that version of Python interpreter:')
-                    debug(f"'python3.8 ./toshy_setup.py [--option]'")
-                    safe_shutdown(1)
+                    try:
+                        # sudo yum install -y centos-release-scl
+                        subprocess.run(['sudo', 'yum', 'install', '-y', 'centos-release-scl'],
+                                        check=True)
+                        # sudo yum install -y rh-python38
+                        subprocess.run(['sudo', 'yum', 'install', '-y', 'rh-python38'],
+                                        check=True)
+                        # scl enable rh-python38 bash
+                        subprocess.run(['scl', 'enable', 'rh-python38', 'bash'],
+                                        check=True)
+                    except subprocess.CalledProcessError as proc_err:
+                        print()
+                        error(f'ERROR: (CentOS-specific) Problem installing/enabling Python 3.8:'
+                                f'\n\t{proc_err}')
+                        safe_shutdown(1)
                 # use yum to install dnf package manager
                 check_for_pkg_mgr_cmd('yum')
                 subprocess.run(['sudo', 'yum', 'install', '-y', 'dnf'])
@@ -632,6 +630,7 @@ def install_distro_pkgs():
                 subprocess.run(['sudo', 'dnf', 'install', '-y'] + cnfg.pkgs_for_distro,
                                 check=True)
         except subprocess.CalledProcessError as proc_err:
+            print()
             error(f'ERROR: Problem installing package list for distro type:\n\t{proc_err}')
             safe_shutdown(1)
 
@@ -642,6 +641,7 @@ def install_distro_pkgs():
             subprocess.run(['sudo', 'zypper', '--non-interactive', 'install'] + cnfg.pkgs_for_distro,
                             check=True)
         except subprocess.CalledProcessError as proc_err:
+            print()
             error(f'ERROR: Problem installing package list for distro type:\n\t{proc_err}')
             safe_shutdown(1)
 
@@ -651,6 +651,7 @@ def install_distro_pkgs():
         try:
             subprocess.run(['sudo', 'apt', 'install', '-y'] + cnfg.pkgs_for_distro, check=True)
         except subprocess.CalledProcessError as proc_err:
+            print()
             error(f'ERROR: Problem installing package list for distro type:\n\t{proc_err}')
             safe_shutdown(1)
 
@@ -671,6 +672,7 @@ def install_distro_pkgs():
             try:
                 subprocess.run(['sudo', 'pacman', '-S', '--noconfirm'] + pkgs_to_install, check=True)
             except subprocess.CalledProcessError as proc_err:
+                print()
                 error(f'ERROR: Problem installing package list for distro type:\n\t{proc_err}')
                 safe_shutdown(1)
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -581,7 +581,7 @@ def install_distro_pkgs():
             call_attention_to_password_prompt()
 
             # do even more prep/checks if distro is CentOS
-            if cnfg.DISTRO_NAME in ['centos'] and cnfg.DISTRO_VER in ['7', '8']:
+            if cnfg.DISTRO_NAME in ['centos'] and cnfg.DISTRO_VER in ['7']:
                 # if py_interp_ver_tup >= curr_py_rel_ver_tup:
                 if py_interp_ver_tup >= (3, 8):
                     print(f"Good, Python version is 3.8 or later: "
@@ -610,7 +610,7 @@ def install_distro_pkgs():
                         cnfg.systemctl_present = False
                     except subprocess.CalledProcessError as proc_err:
                         print()
-                        error(f'ERROR: (CentOS-specific) Problem installing/enabling Python 3.8:'
+                        error(f'ERROR: (CentOS 7-specific) Problem installing/enabling Python 3.8:'
                                 f'\n\t{proc_err}')
                         safe_shutdown(1)
                 # use yum to install dnf package manager
@@ -1235,7 +1235,6 @@ def apply_tweaks_KDE():
     print(f'Disabled Meta key opening application menu. (Use Cmd+Space instead.)')
     
     if cnfg.fancy_pants:
-
         print(f'Installing "Application Switcher" KWin script...')
         # How to install nclarius grouped "Application Switcher" KWin script:
         # git clone https://github.com/nclarius/kwin-application-switcher.git
@@ -1316,6 +1315,9 @@ def apply_desktop_tweaks():
 
     print(f'\n\n§  Applying any known desktop environment tweaks...\n{cnfg.separator}')
 
+    if cnfg.fancy_pants:
+        print(f'Fancy-Pants install invoked. Additional steps will be taken.')
+
     if cnfg.DESKTOP_ENV == 'gnome':
         apply_tweaks_GNOME()
         cnfg.tweak_applied = True
@@ -1326,7 +1328,7 @@ def apply_desktop_tweaks():
 
     # General (not DE specific) "fancy pants" additions:
     if cnfg.fancy_pants:
-        
+
         print(f'Installing font: ', end='', flush=True)
 
         # install Fantasque Sans Mono NoLig (no ligatures) from GitHub fork
@@ -1387,6 +1389,7 @@ def apply_desktop_tweaks():
             print(f'Done.', flush=True)
 
             print(f"Installed font: '{folder_name}'")
+            cnfg.tweak_applied = True
 
     if not cnfg.tweak_applied:
         print(f'If nothing printed, no tweaks available for "{cnfg.DESKTOP_ENV}" yet.')

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -5,7 +5,6 @@ import re
 import sys
 import pwd
 import grp
-import time
 import random
 import string
 import signal
@@ -461,8 +460,6 @@ distro_groups_map = {
     # Add more as needed...
 }
 
-# TODO: On openSUSE, check version of system Python to adapt Python package name
-# openSUSE package is python310-* now but will probably be python311-* soon
 pkg_groups_map = {
     # TODO: remove this package group if the change to RHEL/Fedora works out
     # 'redhat-based':    ["gcc", "git", "cairo-devel", "cairo-gobject-devel", "dbus-devel",
@@ -667,6 +664,7 @@ def merge_slices(data: str, slices: Dict[str, str]) -> str:
 
     return "".join(data_slices)
 
+
 def backup_toshy_config():
     """Backup existing Toshy config folder"""
     print(f'\n\n§  Backing up existing Toshy config folder...\n{cnfg.separator}')
@@ -855,7 +853,6 @@ def install_bin_commands():
     subprocess.run([script_path])
 
 
-# Replace $HOME with user home directory
 def replace_home_in_file(filename):
     """Utility function to replace '$HOME' in .desktop files with actual home path"""
     # Read in the file
@@ -1032,6 +1029,7 @@ def autostart_tray_icon():
     subprocess.run(['ln', '-sf', tray_desktop_file, dest_link_file])
 
     print(f'Toshy tray icon should appear in system tray at each login.')
+
 
 ###################################################################################################
 ##  TWEAKS UTILITY FUNCTIONS - START
@@ -1451,7 +1449,6 @@ def handle_cli_arguments():
         remove_desktop_tweaks()
         safe_shutdown(0)
     elif args.uninstall:
-        # raise NotImplementedError
         uninstall_toshy()
     elif args.fancy_pants:
         cnfg.fancy_pants = True

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -818,14 +818,17 @@ def setup_python_virt_env():
 
     # Create the virtual environment if it doesn't exist
     if not os.path.exists(cnfg.venv_path):
-        # change the Python interpreter path to use the 3.11 version if distro is openSUSE Leap type
+        # change the Python interpreter path to user current release version 
+        # if distro is openSUSE Leap type (instead of old 3.6 version)
         if cnfg.DISTRO_NAME in distro_groups_map['leap-based']:
             if shutil.which(f'python{curr_py_rel_ver}'):
                 cnfg.py_interp_path     = shutil.which(f'python{curr_py_rel_ver}')
+                print(f'Using Python version {curr_py_rel_ver}.')
             else:
                 print(  f'Current stable Python release version '
-                        f'({curr_py_rel_ver}) not found. '
-                        f"Using version: '{py_interp_ver}'")
+                        f'({curr_py_rel_ver}) not found. ')
+        else:
+            print(f'Using Python version {py_interp_ver}.')
         subprocess.run([cnfg.py_interp_path, '-m', 'venv', cnfg.venv_path])
 
     # We do not need to "activate" the venv right now, just create it

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -606,6 +606,8 @@ def install_distro_pkgs():
                         # set new Python interpreter version and path to reflect what was installed
                         cnfg.py_interp_path = '/opt/rh/rh-python38/root/usr/bin/python3.8'
                         cnfg.py_interp_ver  = '3.8'
+                        # avoid using systemd packages/services for CentOS
+                        cnfg.systemctl_present = False
                     except subprocess.CalledProcessError as proc_err:
                         print()
                         error(f'ERROR: (CentOS-specific) Problem installing/enabling Python 3.8:'

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -88,9 +88,6 @@ curr_py_rel_ver_min = 11
 curr_py_rel_ver     = f'{curr_py_rel_ver_maj}.{curr_py_rel_ver_min}'
 curr_py_rel_ver_tup = (curr_py_rel_ver_maj, curr_py_rel_ver_min)
 
-# 'sys.executable' changes if a venv is active! do not use for Python interpreter path!
-py_interp_path = shutil.which('python3')
-
 # Check if 'sudo' command is available to user
 if not shutil.which('sudo'):
     print("Error: 'sudo' not found. Installer will fail without it. Exiting.")
@@ -127,6 +124,7 @@ class InstallerSettings:
         self.pkgs_for_distro        = None
         self.pip_pkgs               = None
         self.qdbus                  = 'qdbus-qt5' if shutil.which('qdbus-qt5') else 'qdbus'
+        self.py_interp_path         = shutil.which('python3')
 
         self.home_dir_path          = os.path.abspath(os.path.expanduser('~'))
         self.toshy_dir_path         = os.path.join(self.home_dir_path, '.config', 'toshy')
@@ -823,12 +821,12 @@ def setup_python_virt_env():
         # change the Python interpreter path to use the 3.11 version if distro is openSUSE Leap type
         if cnfg.DISTRO_NAME in distro_groups_map['leap-based']:
             if shutil.which(f'python{curr_py_rel_ver}'):
-                py_interp_path = shutil.which(f'python{curr_py_rel_ver}')
+                cnfg.py_interp_path     = shutil.which(f'python{curr_py_rel_ver}')
             else:
                 print(  f'Current stable Python release version '
                         f'({curr_py_rel_ver}) not found. '
                         f"Using version: '{py_interp_ver}'")
-        subprocess.run([py_interp_path, '-m', 'venv', cnfg.venv_path])
+        subprocess.run([cnfg.py_interp_path, '-m', 'venv', cnfg.venv_path])
 
     # We do not need to "activate" the venv right now, just create it
     print(f'Python virtual environment setup complete.')

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1494,21 +1494,8 @@ def handle_cli_arguments():
         help='Optional: install font, KDE task switcher, etc...'
     )
 
-    # # Add a catch-all for unknown arguments
-    # parser.add_argument(
-    #     'unknown',
-    #     nargs=argparse.REMAINDER,
-    #     help=argparse.SUPPRESS
-    # )
-
     args = parser.parse_args()
 
-    # # Check for unknown arguments
-    # if args.unknown:
-    #     raise ValueError(   f"ERROR: Unknown argument(s): {args.unknown}\n"
-    #                         f'Check the "--help" output.\n'     )
-
-    # Check that at most one "exit-immediately" argument is true
     exit_args_dct = {
         '--uninstall':          args.uninstall,
         '--show-env':           args.show_env,
@@ -1517,14 +1504,13 @@ def handle_cli_arguments():
         '--remove-tweaks':      args.remove_tweaks
     }
 
-    # Also include the other arguments in the check
     all_args_dct = {
         '--override-distro':    bool(args.override_distro),
         '--fancy-pants':        args.fancy_pants,
         **exit_args_dct
     }
 
-    # Check that at most one argument is true when an "exit-immediately" argument is true
+    # Check that "exit-after" arguments are used alone
     if any(exit_args_dct.values()) and sum(all_args_dct.values()) > 1:
         error(f"ERROR: These options should be used alone:" +
             ''.join(f"\n\t{arg}" for arg in exit_args_dct.keys()))

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1493,19 +1493,19 @@ def handle_cli_arguments():
         help='Optional: install font, KDE task switcher, etc...'
     )
 
-    # Add a catch-all for unknown arguments
-    parser.add_argument(
-        'unknown',
-        nargs=argparse.REMAINDER,
-        help=argparse.SUPPRESS
-    )
+    # # Add a catch-all for unknown arguments
+    # parser.add_argument(
+    #     'unknown',
+    #     nargs=argparse.REMAINDER,
+    #     help=argparse.SUPPRESS
+    # )
 
     args = parser.parse_args()
 
-    # Check for unknown arguments
-    if args.unknown:
-        raise ValueError(   f"ERROR: Unknown argument(s): {args.unknown}\n"
-                            f'Check the "--help" output.\n'     )
+    # # Check for unknown arguments
+    # if args.unknown:
+    #     raise ValueError(   f"ERROR: Unknown argument(s): {args.unknown}\n"
+    #                         f'Check the "--help" output.\n'     )
 
     # Check that at most one "exit-immediately" argument is true
     exit_args_dct = {

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -462,14 +462,11 @@ def verify_user_groups():
 
 
 distro_groups_map = {
-    # TODO: remove this distro group if the change to RHEL/Fedora works out
-    # 'redhat-based':    ["fedora", "fedoralinux", "ultramarine", "nobara",
-    #                     "rhel", "almalinux", "rocky", "eurolinux"],
-
     # separate references for RHEL types versus Fedora types
     'fedora-based':    ["fedora", "fedoralinux", "ultramarine", "nobara", "silverblue"],
     'rhel-based':      ["rhel", "almalinux", "rocky", "eurolinux", "centos"],
 
+    # separate references for Tumbleweed types versus Leap types
     'tumbleweed-based':["opensuse-tumbleweed"],
     'leap-based':      ["opensuse-leap"],
     'ubuntu-based':    ["ubuntu", "mint", "popos", "eos", "neon", "tuxedo", "zorin"],
@@ -479,12 +476,6 @@ distro_groups_map = {
 }
 
 pkg_groups_map = {
-    # TODO: remove this package group if the change to RHEL/Fedora works out
-    # 'redhat-based':    ["gcc", "git", "cairo-devel", "cairo-gobject-devel", "dbus-devel",
-    #                     "python3-dbus", "python3-devel", "python3-pip", "python3-tkinter",
-    #                     "gobject-introspection-devel", "libappindicator-gtk3", "xset",
-    #                     "libnotify", "systemd-devel", "zenity"],
-
     'fedora-based':    ["gcc", "git", "cairo-devel", "cairo-gobject-devel", "dbus-devel",
                         "python3-dbus", "python3-devel", "python3-pip", "python3-tkinter",
                         "gobject-introspection-devel", "libappindicator-gtk3", "xset",
@@ -495,7 +486,6 @@ pkg_groups_map = {
                         "gobject-introspection-devel", "libappindicator-gtk3", "xset",
                         "libnotify", "systemd-devel", "zenity"],
 
-    # opensuse-tumbleweed
     'tumbleweed-based':["gcc", "git", "cairo-devel",  "dbus-1-devel", f"python{py_pkg_ver}-tk",
                         f"python{py_pkg_ver}-dbus-python-devel", f"python{py_pkg_ver}-devel",
                         "gobject-introspection-devel", "libappindicator3-devel", "tk",
@@ -526,10 +516,6 @@ pkg_groups_map = {
 extra_pkgs_map = {
     # Add a distro name and its additional packages here as needed
     # 'distro_name': ["pkg1", "pkg2", ...],
-    # TODO: remove the lines below if the updated RHEL/Fedora distro groups works out
-    # 'fedora':          ["evtest"],
-    # 'fedoralinux':     ["evtest"],
-    # 'ultramarine':     ["evtest"],
 }
 
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+os.environ['PYTHONDONTWRITEBYTECODE'] = '1'     # prevent creation of cache files
 import re
 import sys
 import pwd
@@ -762,6 +763,7 @@ def install_toshy_files():
             installer_dir_path, 
             cnfg.toshy_dir_path, 
             ignore=shutil.ignore_patterns(
+                '__pycache__',
                 '.github',
                 '.gitignore',
                 keyszer_tmp_dir,

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -76,12 +76,6 @@ if sys.prefix != sys.base_prefix:
     sys.path = [p for p in sys.path if not p.startswith(sys.prefix)]
     sys.prefix = sys.base_prefix
 
-# system Python version
-py_ver_major, py_ver_minor = sys.version_info[:2]
-py_interp_ver_tup   = (py_ver_major, py_ver_minor)
-py_interp_ver       = f'{py_ver_major}.{py_ver_minor}'
-py_pkg_ver          = f'{py_ver_major}{py_ver_minor}'
-
 # current stable Python release version (update when needed):
 # 3.11 Release Date: Oct. 24, 2022
 curr_py_rel_ver_maj = 3
@@ -105,6 +99,11 @@ else:
     debug("Home user local bin not part of PATH string.")
 # do the 'else' of creating 'path_fix_tmp_path' later in function that prompts user
 
+# system Python version
+py_ver_major, py_ver_minor  = sys.version_info[:2]
+py_interp_ver_tup      = (py_ver_major, py_ver_minor)
+py_pkg_ver             = f'{py_ver_major}{py_ver_minor}'
+
 
 class InstallerSettings:
     """Set up variables for necessary information to be used by all functions"""
@@ -125,6 +124,8 @@ class InstallerSettings:
         self.pkgs_for_distro        = None
         self.pip_pkgs               = None
         self.qdbus                  = 'qdbus-qt5' if shutil.which('qdbus-qt5') else 'qdbus'
+        
+        self.py_interp_ver          = f'{py_ver_major}.{py_ver_minor}'
         self.py_interp_path         = shutil.which('python3')
 
         self.home_dir_path          = os.path.abspath(os.path.expanduser('~'))
@@ -584,7 +585,7 @@ def install_distro_pkgs():
                 # if py_interp_ver_tup >= curr_py_rel_ver_tup:
                 if py_interp_ver_tup >= (3, 8):
                     print(f"Good, Python version is 3.8 or later: "
-                            f"'{py_interp_ver}'")
+                            f"'{cnfg.py_interp_ver}'")
                 else:
                     try:
                         # sudo yum install -y centos-release-scl
@@ -597,7 +598,10 @@ def install_distro_pkgs():
                         # scl enable rh-python38 bash
                         # subprocess.run(['scl', 'enable', 'rh-python38', 'bash'],
                         #                 check=True)
+                        
+                        # set new Python interpreter version and path to reflect what was installed
                         cnfg.py_interp_path = '/opt/rh/rh-python38/root/usr/bin/python3.8'
+                        cnfg.py_interp_ver  = '3.8'
                     except subprocess.CalledProcessError as proc_err:
                         print()
                         error(f'ERROR: (CentOS-specific) Problem installing/enabling Python 3.8:'
@@ -903,7 +907,7 @@ def setup_python_virt_env():
                 print(  f'Current stable Python release version '
                         f'({curr_py_rel_ver}) not found. ')
         else:
-            print(f'Using Python version {py_interp_ver}.')
+            print(f'Using Python version {cnfg.py_interp_ver}.')
         subprocess.run([cnfg.py_interp_path, '-m', 'venv', cnfg.venv_path])
 
     # We do not need to "activate" the venv right now, just create it

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1517,8 +1517,16 @@ def handle_cli_arguments():
         '--remove-tweaks':      args.remove_tweaks
     }
 
-    if sum(exit_args_dct.values()) > 1:
-        error(f"ERROR: These options are mutually exclusive (use only one):" +
+    # Also include the other arguments in the check
+    all_args_dct = {
+        '--override-distro':    bool(args.override_distro),
+        '--fancy-pants':        args.fancy_pants,
+        **exit_args_dct
+    }
+
+    # Check that at most one argument is true when an "exit-immediately" argument is true
+    if any(exit_args_dct.values()) and sum(all_args_dct.values()) > 1:
+        error(f"ERROR: These options should be used alone:" +
             ''.join(f"\n\t{arg}" for arg in exit_args_dct.keys()))
         safe_shutdown(1)
 


### PR DESCRIPTION
## Changes

- INSTALLER:
    - CentOS 7 / RHEL 7 support (no systemd services, see README)
    - OpenSUSE Leap 15.5 support (probably 15.4 also)
    - Linux Mint 21.2 support (not much different from 21.1)
    - Make sure notifications work on all distros (credit to @apfelchips)
        - Related: #44
    - Make installer work better with Python 3.6.x
    - Work on KDE 4.x by avoiding use of KDE 5.x tools
    - Make sure installer stops if there is a package install problem
    - Rework handling of CLI arguments to be smarter

- CONFIG:
    - Fix typo in terminals class list
    - Mitigation in `matchProps` function for NoneType in window info
    - Konsole tab nav shortcut fix for KDE 4.x

- README:
    - Add notes about CentOS 7 / RHEL 7 support and issues
    - Add notes about openSUSE Leap 15.4/15.5 support
    - Add note about Linux Mint 21.2 (just released) support
