### PR TITLE
Added kali in debian based distro

### DIFF
--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -491,7 +491,7 @@ distro_groups_map = {
     'tumbleweed-based':["opensuse-tumbleweed"],
     'leap-based':      ["opensuse-leap"],
     'ubuntu-based':    ["ubuntu", "mint", "popos", "elementary", "neon", "tuxedo", "zorin"],
-    'debian-based':    ["lmde", "peppermint", "debian"],
+    'debian-based':    ["lmde", "peppermint", "debian", "kali"],
     'arch-based':      ["arch", "arcolinux", "endeavouros", "manjaro"],
     'solus-based':     ["solus"],
     # Add more as needed...


### PR DESCRIPTION
Adding "kali" to the Debian-based distro list. I tried setting up it on my Kali machine it worked but would like someone else to try to set up toshy on my Kali machine with this change. 