### PR TITLE
Support RHEL 8.x, Enter-to-Rename fixes

### DIFF
--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -601,6 +601,8 @@ def install_distro_pkgs():
         # Have something come out even if package list is empty (like Arch after initial run)
         print(f'All necessary native distro packages are installed.')
 
+    distro_major_ver = cnfg.DISTRO_VER[0] if cnfg.DISTRO_VER else 'NO_VER'
+
     if cnfg.DISTRO_NAME in dnf_distros:
 
         # do extra stuff only if distro is a RHEL type (not Fedora type)
@@ -671,7 +673,19 @@ def install_distro_pkgs():
                 check_for_pkg_mgr_cmd('yum')
                 subprocess.run(['sudo', 'yum', 'install', '-y', 'dnf'])
 
-            distro_major_ver = cnfg.DISTRO_VER[0] if cnfg.DISTRO_VER else 'NO_VER'
+            # for libappindicator-gtk3: sudo dnf install -y epel-release
+            subprocess.run(['sudo', 'dnf', 'install', '-y', 'epel-release'])
+            subprocess.run(['sudo', 'dnf', 'update', '-y'])
+
+            if ( not (  cnfg.DISTRO_NAME == 'centos' and 
+                        distro_major_ver in ['7', '8']    ) and 
+                        distro_major_ver in ['9'] ):
+                #
+                # enable "CodeReady Builder" repo for 'gobject-introspection-devel' on RHEL 9.x:
+                # sudo dnf config-manager --set-enabled crb
+                subprocess.run(['sudo', 'dnf', 'config-manager', '--set-enabled', 'crb'])
+
+            # Need to do this AFTER the 'epel-release' install
             if (  cnfg.DISTRO_NAME != 'centos' and 
                     distro_major_ver in ['8']):
                 # enable CRB repo on RHEL 8.x distros:
@@ -702,17 +716,6 @@ def install_distro_pkgs():
                     # if no suitable version was found, print an error message and exit
                     error('ERROR: Did not find any appropriate Python interpreter version.')
                     safe_shutdown(1)
-            elif ( not (  cnfg.DISTRO_NAME == 'centos' and 
-                        distro_major_ver in ['7', '8']    ) and 
-                        distro_major_ver in ['9'] ):
-                #
-                # enable "CodeReady Builder" repo for 'gobject-introspection-devel' on RHEL 9.x:
-                # sudo dnf config-manager --set-enabled crb
-                subprocess.run(['sudo', 'dnf', 'config-manager', '--set-enabled', 'crb'])
-
-            # for libappindicator-gtk3: sudo dnf install -y epel-release
-            subprocess.run(['sudo', 'dnf', 'install', '-y', 'epel-release'])
-            subprocess.run(['sudo', 'dnf', 'update', '-y'])
 
         # finally, do the install of the main list of packages for DNF/RHEL distro types
         try:

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -187,8 +187,8 @@ def show_reboot_prompt():
 
 
 def get_environment_info():
-    """Get back the distro name, distro version, session type and 
-        desktop environment from `env.py` module"""
+    """Get back the distro name (ID), distro version, session type and desktop 
+        environment from `env.py` module"""
     print(f'\n§  Getting environment information...\n{cnfg.separator}')
 
     known_init_systems = {
@@ -543,7 +543,7 @@ pkg_groups_map = {
 }
 
 extra_pkgs_map = {
-    # Add a distro name and its additional packages here as needed
+    # Add a distro name (ID) and its additional packages here as needed
     # 'distro_name': ["pkg1", "pkg2", ...],
 }
 
@@ -807,25 +807,27 @@ def install_distro_pkgs():
 
 
 def get_distro_names():
-    """Utility function to return list of available distro names"""
-
+    """Utility function to return list of available distro names (IDs)"""
     distro_list = []
     for group in distro_groups_map.values():
         distro_list.extend(group)
-
     sorted_distro_list = sorted(distro_list)
-
-    prev_char = sorted_distro_list[0][0]
-    distro_index = prev_char.upper() + ": "  # start with the initial letter
+    prev_char: str = sorted_distro_list[0][0]
+    # start index with the initial letter
+    distro_index = prev_char.upper() + ": "
     for distro in sorted_distro_list:
         if distro[0] != prev_char:
-            distro_index = distro_index[:-2]  # remove last comma and space from previous line
-            distro_index += "\n\t" + distro[0].upper() + ": " + distro + ", "  # start a new line with new initial letter
+            # type hint to help out VSCode syntax highlighter
+            distro: str
+            # remove last comma and space from previous line
+            distro_index = distro_index[:-2]
+            # start a new line with new initial letter
+            distro_index += "\n\t" + distro[0].upper() + ": " + distro + ", "
             prev_char = distro[0]
         else:
             distro_index += distro + ", "
-    distro_index = distro_index[:-2]  # remove last comma and space from the final line
-
+    # remove last comma and space from the final line
+    distro_index = distro_index[:-2]
     return distro_index
 
 
@@ -1708,12 +1710,12 @@ def handle_cli_arguments():
         '--override-distro',
         type=str,
         # dest='override_distro',
-        help=f'Override auto-detection of distro name/type. See "--list-distros"'
+        help=f'Override auto-detection of distro. See "--list-distros"'
     )
     parser.add_argument(
         '--list-distros',
         action='store_true',
-        help='Display list of distro names to use with "--override-distro"'
+        help='Display list of distros to use with "--override-distro"'
     )
     parser.add_argument(
         '--uninstall',
@@ -1772,7 +1774,7 @@ def handle_cli_arguments():
         safe_shutdown(0)
 
     if args.list_distros:
-        print(  f'Distro names known to the Toshy installer (use with "--override-distro" arg):'
+        print(  f'Distros known to the Toshy installer (use with "--override-distro" arg):'
                 f'\n\n\t{get_distro_names()}')
         safe_shutdown(0)
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -491,7 +491,7 @@ distro_groups_map = {
     'tumbleweed-based':["opensuse-tumbleweed"],
     'leap-based':      ["opensuse-leap"],
     'ubuntu-based':    ["ubuntu", "mint", "popos", "elementary", "neon", "tuxedo", "zorin"],
-    'debian-based':    ["lmde", "peppermint", "debian"],
+    'debian-based':    ["lmde", "peppermint", "debian", "kali"],
     'arch-based':      ["arch", "arcolinux", "endeavouros", "manjaro"],
     'solus-based':     ["solus"],
     # Add more as needed...

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -688,13 +688,15 @@ def install_distro_pkgs():
                         break
                     # try to install the corresponding package
                     try:
-                        subprocess.run(['sudo', 'dnf', 'install', '-y', f'python{version}'], check=True)
+                        subprocess.run(['sudo', 'dnf', 'install', '-y',
+                                        f'python{version}', f'python{version}-devel'], check=True)
                         # if the installation succeeds, set the interpreter path and version
                         cnfg.py_interp_path = f'/usr/bin/python{version}'
                         cnfg.py_interp_ver  = version
                         break
                     # if the installation fails, continue with the next version
                     except subprocess.CalledProcessError:
+                        print(f'No match for potential Python version {version}.')
                         continue
                 else:
                     # if no suitable version was found, print an error message and exit

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -691,8 +691,8 @@ def install_distro_pkgs():
                 # enable CRB repo on RHEL 8.x distros:
                 subprocess.run(['sudo', '/usr/bin/crb', 'enable'])
                 #
-                # define a list of potential Python versions to install
-                potential_versions = ['3.15', '3.14', '3.13', '3.12', '3.11', '3.10', '3.9', '3.8']
+                # TODO: Adjust this list according to "current" stable release Python in middle
+                potential_versions = ['3.14', '3.13', '3.12', '3.11', '3.10', '3.9', '3.8']
                 #
                 for version in potential_versions:
                     # check if the version is already installed
@@ -703,7 +703,10 @@ def install_distro_pkgs():
                     # try to install the corresponding package
                     try:
                         subprocess.run(['sudo', 'dnf', 'install', '-y',
-                                        f'python{version}', f'python{version}-devel'], check=True)
+                                        f'python{version}',
+                                        f'python{version}-devel',
+                                        f'python{version}-tkinter'],
+                                        check=True)
                         # if the installation succeeds, set the interpreter path and version
                         cnfg.py_interp_path = f'/usr/bin/python{version}'
                         cnfg.py_interp_ver  = version


### PR DESCRIPTION
## Changes

- ### CONFIG:
    - Stop "Enter to Rename" from affecting things like GNOME overview search if a file manager had the focus when Cmd+Space was used.
- ### INSTALLER:
    - Enable installing on RHEL 8.x and clones in addition to CentOS Stream 8
