### PR TITLE
Restore [#!/usr/bin/env] in shebang lines

### DIFF
--- a/kde-kwin-dbus-service/toshy_kde_dbus_service.py
+++ b/kde-kwin-dbus-service/toshy_kde_dbus_service.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/kde-kwin-dbus-service/toshy_kde_kwin_script_setup.py
+++ b/kde-kwin-dbus-service/toshy_kde_kwin_script_setup.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/lib/env.py
+++ b/lib/env.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import re
 import os

--- a/scripts/bin/toshy-config-restart.sh
+++ b/scripts/bin/toshy-config-restart.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Restart the Toshy manual script

--- a/scripts/bin/toshy-config-start-verbose.sh
+++ b/scripts/bin/toshy-config-start-verbose.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Start the Toshy manual script, with verbose output

--- a/scripts/bin/toshy-config-start.sh
+++ b/scripts/bin/toshy-config-start.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Start the Toshy manual script

--- a/scripts/bin/toshy-config-stop.sh
+++ b/scripts/bin/toshy-config-stop.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Stop the Toshy manual script

--- a/scripts/bin/toshy-devices.sh
+++ b/scripts/bin/toshy-devices.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Show the devices that keyszer sees

--- a/scripts/bin/toshy-env.sh
+++ b/scripts/bin/toshy-env.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Run the Toshy environment module to show what it sees

--- a/scripts/bin/toshy-fnmode.sh
+++ b/scripts/bin/toshy-fnmode.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # Script to change the function keys mode of keyboards that use `hid_apple` device driver
 

--- a/scripts/bin/toshy-gui.sh
+++ b/scripts/bin/toshy-gui.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Start Toshy GUI app after activating venv

--- a/scripts/bin/toshy-kde-dbus-service.sh
+++ b/scripts/bin/toshy-kde-dbus-service.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Start Toshy KDE D-Bus service, after terminating existing

--- a/scripts/bin/toshy-services-disable.sh
+++ b/scripts/bin/toshy-services-disable.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Disable the Toshy services

--- a/scripts/bin/toshy-services-enable.sh
+++ b/scripts/bin/toshy-services-enable.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Disable the Toshy services

--- a/scripts/bin/toshy-services-log.sh
+++ b/scripts/bin/toshy-services-log.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Show the journalctl output of the Toshy systemd services (session monitor and config).

--- a/scripts/bin/toshy-services-restart.sh
+++ b/scripts/bin/toshy-services-restart.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Restart the Toshy services. First stop session monitor so that it doesn't 

--- a/scripts/bin/toshy-services-start.sh
+++ b/scripts/bin/toshy-services-start.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Start the config service, then the session monitor service

--- a/scripts/bin/toshy-services-status.sh
+++ b/scripts/bin/toshy-services-status.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Show the status of the Toshy systemd services (session monitor and config).

--- a/scripts/bin/toshy-services-stop.sh
+++ b/scripts/bin/toshy-services-stop.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Stop the Toshy services. First session monitor so that it doesn't try 

--- a/scripts/bin/toshy-systemd-remove.sh
+++ b/scripts/bin/toshy-systemd-remove.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Stop, disable, and remove the systemd service unit files

--- a/scripts/bin/toshy-systemd-setup.sh
+++ b/scripts/bin/toshy-systemd-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Set up the Toshy systemd services (session monitor and config).

--- a/scripts/bin/toshy-tray.sh
+++ b/scripts/bin/toshy-tray.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Start Toshy GUI app after activating venv

--- a/scripts/bin/toshy-venv.sh
+++ b/scripts/bin/toshy-venv.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # Tell the user how to activate the Toshy Python virtual environment
 

--- a/scripts/toshy-bincommands-remove.sh
+++ b/scripts/toshy-bincommands-remove.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Remove the Toshy bin command symlinks from user-local bin location.

--- a/scripts/toshy-bincommands-setup.sh
+++ b/scripts/toshy-bincommands-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # "Install" the bin commands as symlinks in user-local bin location.

--- a/scripts/toshy-desktopapps-remove.sh
+++ b/scripts/toshy-desktopapps-remove.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Remove the Toshy desktop entry files so that app launchers and menus do not

--- a/scripts/toshy-desktopapps-setup.sh
+++ b/scripts/toshy-desktopapps-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # "Install" the Toshy dekstop entry files so that app launchers and menus can 

--- a/scripts/toshy-kwin-script-kickstart.sh
+++ b/scripts/toshy-kwin-script-kickstart.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # Script to create a KWin event that will get the KWin script to start working
 

--- a/scripts/toshy-service-config-execstartpre.sh
+++ b/scripts/toshy-service-config-execstartpre.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # Do this in ExecStartPre to help the config service script
 

--- a/scripts/toshy-service-config.sh
+++ b/scripts/toshy-service-config.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Start the actual run of the keymapper with Toshy config, making 

--- a/scripts/toshy-service-session-monitor-dbus.sh
+++ b/scripts/toshy-service-session-monitor-dbus.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Monitor whether the user's desktop session is "Active" according to loginctl.

--- a/scripts/toshy-service-session-monitor.sh
+++ b/scripts/toshy-service-session-monitor.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 
 # Monitor whether the user's desktop session is "Active" according to loginctl.

--- a/toshy_gui.py
+++ b/toshy_gui.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Preferences app for Toshy, using tkinter GUI and "Sun Valley" theme

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1821,11 +1821,11 @@ def main(cnfg: InstallerSettings):
 
     elevate_privileges()
 
+    install_distro_pkgs()
+
     load_uinput_module()
     install_udev_rules()
     verify_user_groups()
-
-    install_distro_pkgs()
 
     clone_keyszer_branch()
 

--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import os
 os.environ['PYTHONDONTWRITEBYTECODE'] = '1'     # prevent this script from creating cache files
@@ -490,6 +490,9 @@ distro_groups_map = {
     # separate references for Tumbleweed types versus Leap types
     'tumbleweed-based':["opensuse-tumbleweed"],
     'leap-based':      ["opensuse-leap"],
+
+    'pclinuxos-based': ["pclinuxos"],
+
     'ubuntu-based':    ["ubuntu", "mint", "popos", "elementary", "neon", "tuxedo", "zorin"],
     'debian-based':    ["lmde", "peppermint", "debian", "kali"],
     'arch-based':      ["arch", "arcolinux", "endeavouros", "manjaro"],
@@ -513,6 +516,11 @@ pkg_groups_map = {
                         "gobject-introspection-devel", "libappindicator3-devel", "tk",
                         "libnotify-tools", "typelib-1_0-AyatanaAppIndicator3-0_1",
                         "systemd-devel", "zenity"],
+
+    'pclinuxos-based': ["gcc", "git", "cairo-devel", "cairo-gobject-devel", "dbus-devel", 
+                        "python3-dbus", "python3-devel", "python3-pip", "python3-tkinter", 
+                        "gobject-introspection-devel", "libappindicator3-devel", "xset", 
+                        "libnotify", "systemd-devel", "zenity"],
 
     # TODO: update Leap Python package versions as it makes newer Python available
     'leap-based':      ["gcc", "git", "cairo-devel",  "dbus-1-devel", "python311-tk",

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Indicator tray icon menu app for Toshy, using pygobject/gi


### PR DESCRIPTION
Restore the proper shebang line with /usr/bin/env instead of /bin/env. 

Also, some prep work for supporting PCLinuxOS (incomplete).
