### PR TITLE
add dbus-daemon to the Fedora packages

### DIFF
--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -510,9 +510,9 @@ pkg_groups_map = {
     'test-based':      ["git"],
 
     'fedora-based':    ["gcc", "git", "cairo-devel", "cairo-gobject-devel", "dbus-devel",
-                        "python3-dbus", "python3-devel", "python3-pip", "python3-tkinter",
-                        "gobject-introspection-devel", "libappindicator-gtk3", "xset",
-                        "libnotify", "systemd-devel", "zenity", "evtest"],
+                        "dbus-daemon", "python3-dbus", "python3-devel", "python3-pip",
+                        "python3-tkinter", "gobject-introspection-devel", "libappindicator-gtk3",
+                        "xset", "libnotify", "systemd-devel", "zenity", "evtest"],
 
     'rhel-based':      ["gcc", "git", "cairo-devel", "cairo-gobject-devel", "dbus-devel",
                         "python3-dbus", "python3-devel", "python3-pip", "python3-tkinter",


### PR DESCRIPTION
Without dbus-daemon, dbus-python fails to build.