### PR TITLE
add xf86-input-evdev as arch dep

### DIFF
--- a/toshy_setup.py
+++ b/toshy_setup.py
@@ -450,6 +450,7 @@ pkg_groups_map = {
                         "pkg-config", "python", "python-dbus", "python-pip",
                         "systemd",
                         "tk",
+                        'xf86-input-evdev',
                         "zenity"],
 
     # TODO: see if this needs "dbus-daemon" added as dependency (for containers)


### PR DESCRIPTION
I have added the `xf86-input-evdev` package as a dependency for arch-based distros. Installing without this package will result in a permissions error when trying to write to `/dev/uinput`.