### PR TITLE
Add warp.dev to default terminals

### DIFF
--- a/default-toshy-config/toshy_config.py
+++ b/default-toshy-config/toshy_config.py
@@ -268,7 +268,6 @@ def negRgx(rgx_str):
 #     "tilda",
 #     "tilix",
 #     "urxvt",
-#     "warp.dev"
 #     "xfce4-terminal",
 #     "xterm",
 #     "yakuake",
@@ -282,6 +281,7 @@ terminals_lod = [
     {clas:"^contour$"                   },
     {clas:"^cutefish-terminal$"         },
     {clas:"^deepin-terminal$"           },
+    {clas:"^dev.warp.Warp$"             },
     {clas:"^eterm$"                     },
     {clas:"^gnome-terminal$"            },
     {clas:"^gnome-terminal-server$"     },
@@ -310,7 +310,6 @@ terminals_lod = [
     {clas:"^tilda$"                     },
     {clas:"^tilix$"                     },
     {clas:"^urxvt$"                     },
-    {clas:"^dev.warp.Warp$"             },
     {clas:"^xfce4-terminal$"            },
     {clas:"^xterm$"                     },
     {clas:"^yakuake$"                   },

--- a/default-toshy-config/toshy_config.py
+++ b/default-toshy-config/toshy_config.py
@@ -268,6 +268,7 @@ def negRgx(rgx_str):
 #     "tilda",
 #     "tilix",
 #     "urxvt",
+#     "warp.dev"
 #     "xfce4-terminal",
 #     "xterm",
 #     "yakuake",
@@ -309,6 +310,7 @@ terminals_lod = [
     {clas:"^tilda$"                     },
     {clas:"^tilix$"                     },
     {clas:"^urxvt$"                     },
+    {clas:"^dev.warp.Warp$"             },
     {clas:"^xfce4-terminal$"            },
     {clas:"^xterm$"                     },
     {clas:"^yakuake$"                   },


### PR DESCRIPTION
Warp.dev recently released their terminal in Linux as a beta. This change just adds it to the default set of terminals.

Not sure if this is useful as a PR, feel free to close it out if not.