### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,7 +1039,7 @@ timeouts(
 )
 ```
 
-Save the change to the config file and then restart Toshy from the tray icon, or with `toshy-servcies-restart` in a terminal.  
+Save the change to the config file and then restart Toshy from the tray icon, or with `toshy-services-restart` in a terminal.  
 
 If you do need to disable or reduce the suspend timer because of the touchpad issue, it will become more important to implement the fixes below for VSCode and Firefox, to keep them from focusing the menu bar every time you hit `Option/Alt`.  
 


### PR DESCRIPTION
Typo on `toshy-services-restart`. Originally read as `toshy-servcies-restart`.