### PR TITLE
Add shortcuts for going back and forward in IntelliJ (copied from PR #260)

### DIFF
--- a/default-toshy-config/toshy_config.py
+++ b/default-toshy-config/toshy_config.py
@@ -3453,6 +3453,8 @@ keymap("Jetbrains", {
     C("Super-Shift-b"):         C("C-Shift-b"),                 # Go to type declaration
     C("Super-Up"):              C("Alt-Up"),                    # Go to previous
     C("Super-Down"):            C("Alt-Down"),                  # Go to next method
+    C("C-Left_Brace"):          C("Alt-Shift-Left"),            # Go back
+    C("C-Right_Brace"):         C("Alt-Shift-Right"),           # Go forward
     C("Super-h"):               C("C-h"),                       # Type hierarchy
     C("Super-Alt-h"):           C("C-Alt-h"),                   # Call hierarchy
     C("C-Down"):                C("C-Enter"),                   # Edit source/View source


### PR DESCRIPTION
Copied from PR #260 to re-submit on behalf of the original submitter, because I messed up the contributor instructions and that PR ended up with 168 excess commits from my previous work on the `dev_beta` branch. 

* * * 

<!--
Please submit pull requests on the `dev_beta` branch of the Toshy repo to facilitate
easier testing of the changes before they get merged in with `main`.

Feel free to delete portions of this form that seem unnecessary for a simple PR. 
-->

**Description of the Changes:**
I have mapped `Cmd+[` to `alt+shift+left` and `Cmd+]` to `alt+shift+right` to be able to go back and forward in IntelliJ or other IntelliJ-based IDEs (example CLion or Goland). I have been using this config myself and feel that the community can benefit from it.

**Reason for Changes:**
I have linked the relevant keymaps in IntelliJ source code below for reference.

IntelliJ defaults on MacOS for "Back" and "Forward" are
1. Back = [meta OPEN_BRACKET](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-resources/src/keymaps/Mac%20OS%20X%2010.5%2B.xml#L557)
2. Forward = [meta CLOSE_BRACKET](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-resources/src/keymaps/Mac%20OS%20X%2010.5%2B.xml#L562)

`meta OPEN_BRACKET` translates to `C-Left_Brace`, and `meta CLOSE_BRACKET` translates to `C-Right_Brace` for toshy config.
I would like to be able to use these shortcuts on GNOME.

IntelliJ defaults on GNOME for "Back" and "Forward" are
1. Back = [shift alt LEFT](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-resources/src/keymaps/Default%20for%20GNOME.xml#L3)
2. Forward = [shift alt RIGHT](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-resources/src/keymaps/Default%20for%20GNOME.xml#L17)

**Related Issue(s) or PR(s):**
<!-- Mention any issues or PRs that are connected to this one. -->
#260 

**Testing Done:**
Tested on IntelliJ and Goland in GNOME environment.
