### PR TITLE
Unprivileged user install process

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,14 @@ Just applies the "desktop tweaks" for the environment, does not do the full inst
 
 Just removes the "desktop tweaks" the installer applied. Does not do the full uninstall.  
 
+```sh
+./setup_toshy.py prep-only
+```
+
+This will only perform the necessary steps to "prep" the system to make Toshy's user-specific components work correctly. Things like package installs and setting up the `udev` rules file. This `prep-only` command will avoid installing any of Toshy's user components (user services, tray icon, etc.) for the admin user running the command. 
+
+Invoking this command instead of doing the "install" command may require some extra manual steps to get a user's Toshy install fully working, if the user that wants to use Toshy is a non-admin (unprivileged) user with no access to `sudo`. Mainly this might be adding the unprivileged user to the correct `input` group and restarting the system. See the [dedicated Wiki page]() for more information about the use of the `prep-only` command.  
+
 ## How to Uninstall
 
 This should work now:  

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -440,6 +440,11 @@ def elevate_privileges():
             # set a flag to bypass functions that do system "prep" work with `sudo`
             cnfg.unprivileged_user = True
             cnfg.skip_native = True
+        else:
+            print()
+            error('Code does not match! Try the installer again after installing Toshy \n'
+                    'first using an admin user that has access to "sudo".')
+            safe_shutdown(1)
 
 
 #####################################################################################################

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -1706,18 +1706,12 @@ class PythonVenvQuirksHandler():
     def handle_quirks_CentOS_7(self):
         # avoid using systemd packages/services for CentOS 7
         cnfg.systemctl_present = False
-        # Path where Python 3.8 should be installed by this point
+        # Path where Python 3.8 should have been installed by this point
         rh_python38 = '/opt/rh/rh-python38/root/usr/bin/python3.8'
-        if os.path.exists(rh_python38):
-            # set new Python interpreter version and path to reflect what was installed
-            cnfg.py_interp_path     = rh_python38
-            cnfg.py_interp_ver_str  = '3.8'
-        if py_interp_ver_tup >= (3, 8):
-            print("Good, Python version is 3.8 or later: "
-                    f"'{cnfg.py_interp_ver_str}'")
+        if os.path.isfile(rh_python38) and os.access(rh_python38, os.X_OK):
+            print("Good, Python version 3.8 is installed.")
         else:
-            error("Error: Python version is not 3.8 or later: "
-                    f"'{cnfg.py_interp_ver_str}'")
+            error("Error: Python version 3.8 is not installed. ")
             error("Failed to install Toshy from admin user first?")
             safe_shutdown(1)
 

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -3070,10 +3070,11 @@ def handle_cli_arguments():
         get_environment_info()
         apply_desktop_tweaks()
         if cnfg.should_reboot:
+            lb = cnfg.sep_char * 2      # shorter variable name for left border chars
             show_reboot_prompt()
-            print(f'{cnfg.sep_char * 2}  Tweaks application complete. Report issues on the GitHub repo.')
-            print(f'{cnfg.sep_char * 2}  https://github.com/RedBearAK/toshy/issues/')
-            print(f'{cnfg.sep_char * 2}  >>  ALERT: Something odd happened. You should probably reboot.')
+            print(f'{lb}  Tweaks application complete. Report issues on the GitHub repo.')
+            print(f'{lb}  https://github.com/RedBearAK/toshy/issues/')
+            print(f'{lb}  >>  ALERT: Something odd happened. You should probably reboot.')
             print(cnfg.separator)
             print(cnfg.separator)
             print()
@@ -3180,10 +3181,11 @@ def main(cnfg: InstallerSettings):
             # create reboot reminder temp file, in case installer is run again before a reboot
             if not os.path.exists(cnfg.reboot_tmp_file):
                 os.mknod(cnfg.reboot_tmp_file)
+            lb = cnfg.sep_char * 2      # shorter variable name for left border chars
             show_reboot_prompt()
-            print(f'{cnfg.sep_char * 2}  Toshy install complete. Report issues on the GitHub repo.')
-            print(f'{cnfg.sep_char * 2}  https://github.com/RedBearAK/toshy/issues/')
-            print(f'{cnfg.sep_char * 2}  >>  ALERT: Permissions changed. You MUST reboot for Toshy to work.')
+            print(f'{lb}  Toshy install complete. Report issues on the GitHub repo.')
+            print(f'{lb}  https://github.com/RedBearAK/toshy/issues/')
+            print(f'{lb}  >>  ALERT: Permissions changed. You MUST reboot for Toshy to work.')
             print(cnfg.separator)
             print(cnfg.separator)
             print()
@@ -3197,14 +3199,16 @@ def main(cnfg: InstallerSettings):
                 # Also, suppress output that might confuse the user
                 subprocess.Popen(tray_icon_cmd, close_fds=True, stdout=DEVNULL, stderr=DEVNULL)
 
+            lb = cnfg.sep_char * 2      # shorter variable name for left border chars
+
             print()
             print()
             print()
             print(cnfg.separator)
             print(cnfg.separator)
-            print(f'{cnfg.sep_char * 2}  Toshy install complete. Rebooting should not be necessary.')
-            print(f'{cnfg.sep_char * 2}  Report issues on the GitHub repo.')
-            print(f'{cnfg.sep_char * 2}  https://github.com/RedBearAK/toshy/issues/')
+            print(f'{lb}  Toshy install complete. Rebooting should not be necessary.')
+            print(f'{lb}  Report issues on the GitHub repo.')
+            print(f'{lb}  https://github.com/RedBearAK/toshy/issues/')
             print(cnfg.separator)
             print(cnfg.separator)
             print()

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -436,8 +436,11 @@ def elevate_privileges():
         cmd_lst = ['sudo', 'bash', '-c', 'echo -e "\nUsing elevated privileges..."']
         subprocess.run(cmd_lst, check=True)
     except subprocess.CalledProcessError as proc_err:
+        if cnfg.prep_only:
+            error('Only an admin user with sudo access can use "prep-only".')
+            safe_shutdown(1)
         secret_code = generate_secret_code()
-        error(f'There was a problem checking "sudo" availability:\n\t{proc_err}')
+        error(f'There was a problem checking "sudo" availability.') # :\n\t{proc_err}')
         print()
         print(f'The secret code for this run is "{secret_code}".')
         print()

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -1778,8 +1778,8 @@ def setup_python_vir_env():
         elif cnfg.DISTRO_ID in distro_groups_map['rhel-based']:
             venv_quirks_handler.handle_quirks_RHEL()
         try:
-            venv_cmd_lst = [cnfg.py_interp_path, '-m', 'venv', cnfg.venv_path]
             print(f'Using Python version {cnfg.py_interp_ver_str}.')
+            venv_cmd_lst = [cnfg.py_interp_path, '-m', 'venv', cnfg.venv_path]
             subprocess.run(venv_cmd_lst, check=True)
             if cnfg.DISTRO_ID in ['openmandriva']:
                 venv_quirks_handler.handle_quirks_OpenMandriva(venv_cmd_lst)

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -551,6 +551,8 @@ pkg_groups_map: Dict[str, List[str]] = {
                             "xset",
                             "zenity"],
 
+    # NOTE: Do not add 'gnome-shell-extension-appindicator' to Fedora/RHELs.
+    #       This will install extension but requires logging out of GNOME to activate.
     'rhel-based':          ["cairo-devel", "cairo-gobject-devel",
                             "dbus-daemon", "dbus-devel",
                             "gcc", "git", "gobject-introspection-devel",
@@ -560,6 +562,8 @@ pkg_groups_map: Dict[str, List[str]] = {
                             "xset",
                             "zenity"],
 
+    # NOTE: Do not add 'gnome-shell-extension-appindicator' to Fedora/RHELs.
+    #       This will install extension but requires logging out of GNOME to activate.
     'fedora-immutables':   ["cairo-devel", "cairo-gobject-devel",
                             "dbus-daemon", "dbus-devel",
                             "evtest",
@@ -668,6 +672,7 @@ pkg_groups_map: Dict[str, List[str]] = {
                             "systemd-devel",
                             "zenity"],
 
+    # TODO: see if this needs "dbus-daemon" added as dependency (for containers)
     'void-based':          ["cairo-devel", "curl",
                             "dbus-devel",
                             "evtest",
@@ -679,6 +684,7 @@ pkg_groups_map: Dict[str, List[str]] = {
                             "xset",
                             "zenity"],
 
+    # TODO: see if this needs "dbus-daemon" added as dependency (for containers)
     'kaos-based':          ["cairo",
                             "dbus",
                             "evtest",

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -725,10 +725,11 @@ class DistroQuirksHandler:
     def handle_quirks_CentOS_7(self):
         print('Doing prep/checks for CentOS 7...')
 
-        # pin 'evdev' pip package to version 1.6.1 for CentOS 7 to
-        # deal with ImportError and undefined symbol UI_GET_SYSNAME
-        global pip_pkgs
-        pip_pkgs = [pkg if pkg != "evdev" else "evdev==1.6.1" for pkg in pip_pkgs]
+        # Doing this now in the pip packages install function:
+        # # pin 'evdev' pip package to version 1.6.1 for CentOS 7 to
+        # # deal with ImportError and undefined symbol UI_GET_SYSNAME
+        # global pip_pkgs
+        # pip_pkgs = [pkg if pkg != "evdev" else "evdev==1.6.1" for pkg in pip_pkgs]
 
         native_pkg_installer.check_for_pkg_mgr_cmd('yum')
         yum_cmd_lst = ['sudo', 'yum', 'install', '-y']
@@ -1795,6 +1796,12 @@ def install_pip_packages():
     print(f'\n\n§  Installing/upgrading Python packages...\n{cnfg.separator}')
     venv_python_cmd = os.path.join(cnfg.venv_path, 'bin', 'python')
     venv_pip_cmd    = os.path.join(cnfg.venv_path, 'bin', 'pip')
+
+    if cnfg.DISTRO_ID == 'centos' and cnfg.distro_mjr_ver == '7':
+        # pin 'evdev' pip package to version 1.6.1 for CentOS 7 to
+        # deal with ImportError and undefined symbol UI_GET_SYSNAME
+        global pip_pkgs
+        pip_pkgs = [pkg if pkg != "evdev" else "evdev==1.6.1" for pkg in pip_pkgs]
 
     # Filter out systemd packages if no 'systemctl' present
     filtered_pip_pkgs   = [

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -292,6 +292,11 @@ def get_environment_info():
         # we don't care what it is, just that it is set to avoid errors in get_env_info()
         os.environ['XDG_SESSION_DESKTOP'] = 'prep-only'
 
+    if cnfg.prep_only and not os.environ.get('XDG_SESSION_TYPE'):
+        # su-ing to an admin user will show no graphical environment info
+        # we don't care what it is, just that it is set to avoid errors in get_env_info()
+        os.environ['XDG_SESSION_TYPE'] = 'prep-only'
+
     env_info_dct   = env.get_env_info()
 
     # Avoid casefold() errors by converting all to strings

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -1738,7 +1738,7 @@ class PythonVenvQuirksHandler():
         # if distro is openSUSE Leap type (instead of using old 3.6 Python version).
         if shutil.which(f'python{cnfg.curr_py_rel_ver_str}'):
             cnfg.py_interp_path = shutil.which(f'python{cnfg.curr_py_rel_ver_str}')
-            print(f'Using Python version {cnfg.curr_py_rel_ver_str}.')
+            # print(f'Using Python version {cnfg.curr_py_rel_ver_str}.')
         else:
             print(  f'Current stable Python release version '
                     f'({cnfg.curr_py_rel_ver_str}) not found. ')
@@ -1771,19 +1771,18 @@ def setup_python_vir_env():
     if not os.path.exists(cnfg.venv_path):
         if cnfg.DISTRO_ID in distro_groups_map['leap-based']:
             venv_quirks_handler.handle_quirks_Leap()
-        else:
-            print(f'Using Python version {cnfg.py_interp_ver_str}.')
+        elif cnfg.DISTRO_ID == 'centos' and cnfg.distro_mjr_ver == '7':
+            venv_quirks_handler.handle_quirks_CentOS_7()
+        elif cnfg.DISTRO_ID == 'centos' and cnfg.distro_mjr_ver == '8':
+            venv_quirks_handler.handle_quirks_CentOS_Stream_8()
+        elif cnfg.DISTRO_ID in distro_groups_map['rhel-based']:
+            venv_quirks_handler.handle_quirks_RHEL()
         try:
             venv_cmd_lst = [cnfg.py_interp_path, '-m', 'venv', cnfg.venv_path]
-            if cnfg.DISTRO_ID == 'centos' and cnfg.distro_mjr_ver == '7':
-                venv_quirks_handler.handle_quirks_CentOS_7()
-            elif cnfg.DISTRO_ID == 'centos' and cnfg.distro_mjr_ver == '8':
-                venv_quirks_handler.handle_quirks_CentOS_Stream_8()
-            elif cnfg.DISTRO_ID in ['openmandriva']:
-                venv_quirks_handler.handle_quirks_OpenMandriva(venv_cmd_lst)
-            elif cnfg.DISTRO_ID in distro_groups_map['rhel-based']:
-                venv_quirks_handler.handle_quirks_RHEL()
+            print(f'Using Python version {cnfg.py_interp_ver_str}.')
             subprocess.run(venv_cmd_lst, check=True)
+            if cnfg.DISTRO_ID in ['openmandriva']:
+                venv_quirks_handler.handle_quirks_OpenMandriva(venv_cmd_lst)
         except subprocess.CalledProcessError as proc_err:
             error(f'ERROR: Problem creating the Python virtual environment:\n\t{proc_err}')
             safe_shutdown(1)

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -2944,10 +2944,10 @@ def main(cnfg: InstallerSettings):
     if not cnfg.prep_only:
         ask_add_home_local_bin()
 
-        get_environment_info()
+    get_environment_info()
 
-        if cnfg.DISTRO_ID not in get_supported_distro_ids():
-            exit_with_invalid_distro_error()
+    if cnfg.DISTRO_ID not in get_supported_distro_ids():
+        exit_with_invalid_distro_error()
 
     elevate_privileges()
 

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -1704,11 +1704,19 @@ class PythonVenvQuirksHandler():
         pass
 
     def handle_quirks_CentOS_7(self):
+        # avoid using systemd packages/services for CentOS 7
+        cnfg.systemctl_present = False
+        # Path where Python 3.8 should be installed by this point
+        rh_python38 = '/opt/rh/rh-python38/root/usr/bin/python3.8'
+        if os.path.exists(rh_python38):
+            # set new Python interpreter version and path to reflect what was installed
+            cnfg.py_interp_path     = rh_python38
+            cnfg.py_interp_ver_str  = '3.8'
         if py_interp_ver_tup >= (3, 8):
-            print(f"Good, Python version is 3.8 or later: "
+            print("Good, Python version is 3.8 or later: "
                     f"'{cnfg.py_interp_ver_str}'")
         else:
-            error(f"Error: Python version is not 3.8 or later: "
+            error("Error: Python version is not 3.8 or later: "
                     f"'{cnfg.py_interp_ver_str}'")
             error("Failed to install Toshy from admin user first?")
             safe_shutdown(1)

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -1744,6 +1744,13 @@ class PythonVenvQuirksHandler():
                     f'({cnfg.curr_py_rel_ver_str}) not found. ')
             safe_shutdown(1)
 
+    def handle_quirks_OpenMandriva(self, venv_cmd_lst):
+        print('Handling a Python virtual environment quirk in OpenMandriva...')
+        # We need to run the exact same command twice on OpenMandriva, for unknown reasons.
+        # So this instance of the command is just "prep" for the seemingly duplicate
+        # command that follows it in setup_python_vir_env(). 
+        subprocess.run(venv_cmd_lst, check=True)
+
     def handle_quirks_RHEL(self):
         """Use a newer Python version for the venv in RHEL"""
         # TODO: Add higher version if ever necessary (keep minimum 3.8)
@@ -1754,13 +1761,6 @@ class PythonVenvQuirksHandler():
                 cnfg.py_interp_path     = f'/usr/bin/python{version}'
                 cnfg.py_interp_ver_str  = version
                 break
-
-    def handle_quirks_OpenMandriva(self, venv_cmd_lst):
-        print('Handling a Python virtual environment quirk in OpenMandriva...')
-        # We need to run the exact same command twice on OpenMandriva, for unknown reasons.
-        # So this instance of the command is just "prep" for the seemingly duplicate
-        # command that follows it in setup_python_vir_env(). 
-        subprocess.run(venv_cmd_lst, check=True)
 
 
 def setup_python_vir_env():
@@ -1776,13 +1776,13 @@ def setup_python_vir_env():
         try:
             venv_cmd_lst = [cnfg.py_interp_path, '-m', 'venv', cnfg.venv_path]
             if cnfg.DISTRO_ID == 'centos' and cnfg.distro_mjr_ver == '7':
-                venv_quirks_handler.handle_quirks_CentOS_7(venv_cmd_lst)
+                venv_quirks_handler.handle_quirks_CentOS_7()
             elif cnfg.DISTRO_ID == 'centos' and cnfg.distro_mjr_ver == '8':
-                venv_quirks_handler.handle_quirks_CentOS_Stream_8(venv_cmd_lst)
+                venv_quirks_handler.handle_quirks_CentOS_Stream_8()
             elif cnfg.DISTRO_ID in ['openmandriva']:
                 venv_quirks_handler.handle_quirks_OpenMandriva(venv_cmd_lst)
             elif cnfg.DISTRO_ID in distro_groups_map['rhel-based']:
-                venv_quirks_handler.handle_quirks_RHEL(venv_cmd_lst)
+                venv_quirks_handler.handle_quirks_RHEL()
             subprocess.run(venv_cmd_lst, check=True)
         except subprocess.CalledProcessError as proc_err:
             error(f'ERROR: Problem creating the Python virtual environment:\n\t{proc_err}')

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -355,7 +355,7 @@ def show_task_completed_msg():
 
 
 def generate_secret_code(length=4):
-    """Return a random alphanumeric code of specified length"""
+    """Return a random ASCII letters code of specified length"""
     return ''.join(random.choice(string.ascii_letters) for _ in range(length))
 
 
@@ -718,8 +718,6 @@ class DistroQuirksHandler:
         need some extra prep work before installing the native package list"""
 
     def __init__(self) -> None:
-        # need this to avoid duplicating Python version checks
-        self.venv_quirks_handler = PythonVenvQuirksHandler()
         self.venv_cmd_lst = [cnfg.py_interp_path, '-m', 'venv', cnfg.venv_path]
 
 
@@ -766,21 +764,20 @@ class DistroQuirksHandler:
 
     def handle_quirks_CentOS_Stream_8(self):
         print('Doing prep/checks for CentOS Stream 8...')
-        # min_mnr_ver = cnfg.curr_py_rel_ver_mnr - 3           # check up to 2 vers before current
-        # max_mnr_ver = cnfg.curr_py_rel_ver_mnr + 3           # check up to 3 vers after current
-        # py_minor_ver_rng = range(max_mnr_ver, min_mnr_ver, -1)
-        # if py_interp_ver_tup < cnfg.curr_py_rel_ver_tup:
-        #     print(f"Checking for appropriate Python version on system...")
-        #     for check_py_minor_ver in py_minor_ver_rng:
-        #         if shutil.which(f'python3.{check_py_minor_ver}'):
-        #             cnfg.py_interp_path = shutil.which(f'python3.{check_py_minor_ver}')
-        #             cnfg.py_interp_ver_str = f'3.{check_py_minor_ver}'
-        #             print(f'Found Python version {cnfg.py_interp_ver_str} available.')
-        #             break
-        #     else:
-        #         error(  f'ERROR: Did not find any appropriate Python interpreter version.')
-        #         safe_shutdown(1)
-        self.venv_quirks_handler.handle_quirks_CentOS_Stream_8()
+        min_mnr_ver = cnfg.curr_py_rel_ver_mnr - 3           # check up to 2 vers before current
+        max_mnr_ver = cnfg.curr_py_rel_ver_mnr + 3           # check up to 3 vers after current
+        py_minor_ver_rng = range(max_mnr_ver, min_mnr_ver, -1)
+        if py_interp_ver_tup < cnfg.curr_py_rel_ver_tup:
+            print(f"Checking for appropriate Python version on system...")
+            for check_py_minor_ver in py_minor_ver_rng:
+                if shutil.which(f'python3.{check_py_minor_ver}'):
+                    cnfg.py_interp_path = shutil.which(f'python3.{check_py_minor_ver}')
+                    cnfg.py_interp_ver_str = f'3.{check_py_minor_ver}'
+                    print(f'Found Python version {cnfg.py_interp_ver_str} available.')
+                    break
+            else:
+                error(  f'ERROR: Did not find any appropriate Python interpreter version.')
+                safe_shutdown(1)
         try:
             # for dbus-python
             subprocess.run(['sudo', 'dnf', 'install', '-y',

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -424,7 +424,8 @@ def elevate_privileges():
     """Elevate privileges early in the installer process"""
     call_attn_to_pwd_prompt_if_sudo_tkt_exp()
     try:
-        subprocess.run(['sudo', 'bash', '-c', 'echo -e "\nUsing elevated privileges..."'], check=True)
+        cmd_lst = ['sudo', 'bash', '-c', 'echo -e "\nUsing elevated privileges..."']
+        subprocess.run(cmd_lst, check=True)
     except subprocess.CalledProcessError as proc_err:
         secret_code = generate_secret_code()
         error(f'There was a problem checking "sudo" availability:\n\t{proc_err}')

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -2964,14 +2964,20 @@ def main(cnfg: InstallerSettings):
     if not cnfg.unprivileged_user:
         # These things require 'sudo' (admin user)
         # Allow them to be skipped to support non-admin users
-        # (An admin user would need to do the "prep" install)
-        # TODO: Add an installer option to do "--prep-only" if 
-        # admin user does not want Toshy enabled.
+        # (An admin user would need to first do the "prep-only" command to support this)
         load_uinput_module()
         install_udev_rules()
-        verify_user_groups()
+        if not cnfg.prep_only:
+            # We don't need to check the user group for admin doing prep-only command
+            verify_user_groups()
 
-    if not cnfg.prep_only:
+    if cnfg.prep_only:
+        print()
+        print('########################################################################')
+        print('FINISHED with prep-only tasks. Unprivileged users can now install Toshy.')
+        safe_shutdown(0)
+
+    elif not cnfg.prep_only:
         clone_keymapper_branch()
 
         backup_toshy_config()

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -492,7 +492,8 @@ def elevate_privileges():
         if response == secret_code:
             # set a flag to bypass functions that do system "prep" work with `sudo`
             cnfg.unprivileged_user = True
-            print("Continuing with an unprivileged install of Toshy's user components.")
+            print()
+            print("Continuing with an unprivileged install of Toshy's user components...")
             return
         else:
             print()

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -290,12 +290,12 @@ def get_environment_info():
     if cnfg.prep_only and not os.environ.get('XDG_SESSION_DESKTOP'):
         # su-ing to an admin user will show no graphical environment info
         # we don't care what it is, just that it is set to avoid errors in get_env_info()
-        os.environ['XDG_SESSION_DESKTOP'] = 'prep-only'
+        os.environ['XDG_SESSION_DESKTOP'] = 'gnome'
 
     if cnfg.prep_only and not os.environ.get('XDG_SESSION_TYPE'):
         # su-ing to an admin user will show no graphical environment info
         # we don't care what it is, just that it is set to avoid errors in get_env_info()
-        os.environ['XDG_SESSION_TYPE'] = 'prep-only'
+        os.environ['XDG_SESSION_TYPE'] = 'x11'
 
     env_info_dct   = env.get_env_info()
 

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -780,7 +780,7 @@ class DistroQuirksHandler:
         #     else:
         #         error(  f'ERROR: Did not find any appropriate Python interpreter version.')
         #         safe_shutdown(1)
-        self.venv_quirks_handler.handle_quirks_CentOS_Stream_8(self.venv_cmd_lst)
+        self.venv_quirks_handler.handle_quirks_CentOS_Stream_8()
         try:
             # for dbus-python
             subprocess.run(['sudo', 'dnf', 'install', '-y',

--- a/toshy_gui.py
+++ b/toshy_gui.py
@@ -4,7 +4,7 @@
 # Preferences app for Toshy, using tkinter GUI and "Sun Valley" theme
 TOSHY_PART      = 'gui'   # CUSTOMIZE TO SPECIFIC TOSHY COMPONENT! (gui, tray, config)
 TOSHY_PART_NAME = 'Toshy Preferences app'  # pretty name to print out
-APP_VERSION     = '2024.0202'
+APP_VERSION     = '2024.0508'
 
 # -------- COMMON COMPONENTS --------------------------------------------------
 
@@ -12,7 +12,10 @@ import os
 import re
 import sys
 import time
-import dbus
+try:
+    import dbus
+except ModuleNotFoundError:
+    dbus = None
 import fcntl
 import psutil
 import shutil
@@ -259,6 +262,10 @@ svc_status_glyph_unknown    = 'Unknown '              # ❔  #
 
 
 def fn_monitor_toshy_services():
+    if dbus is None:
+        error('The "dbus" module is not available. Cannot monitor services.')
+        return
+
     # debug('')
     # debug(f'Entering GUI monitoring function...')
     global svc_status_config, svc_status_sessmon

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -4,14 +4,17 @@
 # Indicator tray icon menu app for Toshy, using pygobject/gi
 TOSHY_PART      = 'tray'   # CUSTOMIZE TO SPECIFIC TOSHY COMPONENT! (gui, tray, config)
 TOSHY_PART_NAME = 'Toshy Tray Icon app'
-APP_VERSION     = '2024.0330'
+APP_VERSION     = '2024.0508'
 
 # -------- COMMON COMPONENTS --------------------------------------------------
 
 import os
 import re
 import sys
-import dbus
+try:
+    import dbus
+except ModuleNotFoundError:
+    dbus = None
 import time
 import fcntl
 import psutil
@@ -274,6 +277,10 @@ tray_indicator.set_title("Toshy Status Indicator") # try to set what might show 
 
 
 def fn_monitor_toshy_services():
+    if dbus is None:
+        error('The "dbus" module is not available. Cannot monitor services.')
+        return
+
     global svc_status_config, svc_status_sessmon
     toshy_svc_config_unit_state = None
     toshy_svc_sessmon_unit_state = None


### PR DESCRIPTION
**Description of the Changes:**

- Updated installer to work for unprivileged users.
- Added `prep-only` command (an alternative to `install` command) for use by an admin user to support unprivileged user installs without fully performing install as admin user.
- Reworked `venv` handling logic.
- Documented `prep-only` usage in README and Wiki.
- Added a utility function `md_wrap()` that allows formatting blocks of quoted text in the code (meant to be printed out in terminal) similarly to Markdown. Will apply its own wrapping and formatting when printing out the text, defaulting to 80 characters suitable for most terminal output, and adding its own line breaks sort of like Markdown syntax rules, without needing to insert a bunch of "\n" at manually wrapped line lengths. Makes it much easier to make changes in large blocks of text. 

**Reason for Changes:**

A user was unable to install Toshy from an unprivileged user account, but had access to an admin account that could be used to "prep" the system for the unprivileged user to be able to install and use Toshy. Certain parts of the install needed to be tagged with a control variable so that privileged steps (using `sudo`) could be bypassed for an unprivileged user install. Works only if an admin user already took care of the "prep" steps, such as some native package installs and `udev` rules setup. 

**Related Issue(s) or PR(s):**

#278

**Testing Done:**

User has reported success with installing as unprivileged user on RHEL 8.9, after prepping from an admin user with `prep-only`. Also tested the process in a VM using AlmaLinux 8.9. Other distro installs and standard `install` command were checked in other VMs to verify regular install sequence has not been affected. 
