### PR TITLE
Disable OptSpec layout by default (performance)

### DIFF
--- a/lib/settings_class.py
+++ b/lib/settings_class.py
@@ -28,7 +28,8 @@ class Settings:
         self.autostart_tray_icon    = True              # Default: True
         self.gui_dark_theme         = True              # Default: True
         self.override_kbtype        = 'Auto-Adapt'      # Default: 'Auto-Adapt'
-        self.optspec_layout         = 'US'              # Default: 'US'
+            ###  Disable optspec_layout by default for performance, and international keyboard users
+        self.optspec_layout         = 'Disabled'        # Default: 'Disabled'
         self.mru_layout             = ('us', 'default') # Default: ('us', 'default')
         self.forced_numpad          = True              # Default: True
         self.media_arrows_fix       = False             # Default: False


### PR DESCRIPTION
Disabling the OptSpec layout offers a slight performance increase (more significant on really old dual-core CPUs), and it also interferes with using "Macintosh" keyboard layout variants, and international keyboard users. 

It's very easy to turn it back on to "US" or "ABC" layout, so we'll just disable it by default. Very few users really need it. 