### PR TITLE
Support beta release of Zen browser

### DIFF
--- a/default-toshy-config/toshy_config.py
+++ b/default-toshy-config/toshy_config.py
@@ -597,6 +597,7 @@ browsers_firefox = [
     "zen",
     "zen-bin",
     "zen-alpha",
+    "zen-beta",
     "zen-twilight",
 ]
 browsers_firefox        = [x.casefold() for x in browsers_firefox]


### PR DESCRIPTION
Zen Browser just released their beta version, and the beta uses a different window class name `zen-beta`.