### PR TITLE
Add ghostty keys

### DIFF
--- a/default-toshy-config/toshy_config.py
+++ b/default-toshy-config/toshy_config.py
@@ -4259,6 +4259,9 @@ keymap("Deepin Terminal overrides", {
 
 keymap("Ghostty terminal overrides", {
     C("RC-Equal"):              C("C-Equal"),                   # Increase font size [override general terminals remap]
+    C("RC-D"):                  C("RC-Shift-O"),                # Open right split
+    C("RC-Shift-D"):            C("RC-Shift-E"),                # Open down split
+    C("RC-Alt-I"):              C("RC-Shift-I"),                 # Open inspector
 }, when = matchProps(clas="^ghostty$|^ghostty-debug$|^com.mitchellh.ghostty$"))
 
 keymap("Hyper terminal tab switching", {


### PR DESCRIPTION
**Description of the Changes:**
Added right, down split and terminal inspector overrides based on what my mac does with Ghostty

**Reason for Changes:**
New terminal with new overrides

**Related Issue(s) or PR(s):**


**Testing Done:**
Tested in my own modmap section
