### PR TITLE
Add clear log for ghostty and konsole

### DIFF
--- a/default-toshy-config/toshy_config.py
+++ b/default-toshy-config/toshy_config.py
@@ -4281,7 +4281,7 @@ keymap("Kitty terminal - not tab nav", {
 keymap("Konsole terminal - not tab nav", {
     C("RC-comma"):              C("Shift-C-comma"),             # Open Preferences dialog
     C("RC-0"):                  C("C-Alt-0"),                   # Reset font size
-    C("RC-K"):                  C("C-L"),                       # clear log
+    C("RC-K"):                  C("Shift-C-K"),                 # clear log
 }, when = matchProps(clas="^Konsole$|^org.kde.Konsole$"))
 
 keymap("Terminology terminal", {

--- a/default-toshy-config/toshy_config.py
+++ b/default-toshy-config/toshy_config.py
@@ -4263,7 +4263,8 @@ keymap("Ghostty terminal overrides", {
     C("RC-Equal"):              C("C-Equal"),                   # Increase font size [override general terminals remap]
     C("RC-D"):                  C("RC-Shift-O"),                # Open right split
     C("RC-Shift-D"):            C("RC-Shift-E"),                # Open down split
-    C("RC-Alt-I"):              C("RC-Shift-I"),                 # Open inspector
+    C("RC-Alt-I"):              C("RC-Shift-I"),                # Open inspector
+    C("RC-K"):                  C("C-L"),                       # clear log
 }, when = matchProps(clas="^ghostty$|^ghostty-debug$|^com.mitchellh.ghostty$"))
 
 keymap("Hyper terminal tab switching", {
@@ -4280,6 +4281,7 @@ keymap("Kitty terminal - not tab nav", {
 keymap("Konsole terminal - not tab nav", {
     C("RC-comma"):              C("Shift-C-comma"),             # Open Preferences dialog
     C("RC-0"):                  C("C-Alt-0"),                   # Reset font size
+    C("RC-K"):                  C("C-L"),                       # clear log
 }, when = matchProps(clas="^Konsole$|^org.kde.Konsole$"))
 
 keymap("Terminology terminal", {


### PR DESCRIPTION
**Description of the Changes:**
Add Cmd+K behavior to Ghostty and Konsole

**Reason for Changes:**
Missing mapping that binds mac like terminal clear to ghostty and konsole

**Related Issue(s) or PR(s):**
<!-- Mention any issues or PRs that are connected to this one. -->

**Testing Done:**
Tested in Ghostty and Konsole on my Debian 12 desktop

I am unsure if this applied to other terminals. I saw the override in Alacritty but was not sure if this should be applied to all terminals. I have only used iTerm and Ghostty on my mac.
