### PR TITLE
Chimera support, doas/run0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ I don't really know many other places where it might be considered appropriate t
 
 # Current status: Stable Beta (Please Read)
 
+**2025-03-13 UPDATE**: Added support for Chimera Linux, an independent distro with BSD userland utilities. GUI preferences app will not work until someone finds the Python Tkinter package.
+
 **2025-03-02 UPDATE**: The solution for working with Synergy as a server/host system was expanded to support Deskflow, Input Leap and Barrier. (Requires working log file for the KVM switch app in all cases.) Client systems are ignored because input cannot be detected by the keymapper.
 
 **2025-01-18 UPDATE**: Fixed some issues in the `wlroots` window context method, and verified the bulk of the available LXQt Wayland session options seem to work. That includes `labwc`, `sway`, `Hyprland`, `niri`, `wayfire`, and `river` (tested on Tumbleweed). The `kwin_wayland` session option is still untested (unavailable on Tumbleweed for now).
@@ -536,6 +538,7 @@ See above section for the GUI tools and preferences explanations. This section i
 
 Toshy does its best to set itself up automatically on any Linux system that uses `systemd` and that is a "known" Linux distro type that the installer knows how to deal with (i.e., has a list of the correct native support packages to install, and knows how to use the package manager). Generally this means distros that use one of these package managers:  
 
+- `apk`
 - `apt`
 - `dnf`
 - `eopkg`

--- a/scripts/plasma-task-switcher-fixer.sh
+++ b/scripts/plasma-task-switcher-fixer.sh
@@ -266,8 +266,10 @@ if [ "$KDE_ver" = "5" ] || [ "$KDE_ver" = "6" ]; then
             
             echo "If global shortcuts do not work, please log out and back in."
         else
-            echo "The $kglobalaccel_cmd command is not available."
-            echo "You must log out to activate modified shortcuts."
+            if [ "$KDE_ver" = "5" ] || [ "$KDE_ver" = "4" ]; then
+                echo "The $kglobalaccel_cmd command is not available."
+            fi
+            echo "You MUST log out to activate modified shortcuts."
         fi
 
     fi

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -288,8 +288,9 @@ class InstallerSettings:
 
         for cmd in elevation_cmds:
             if shutil.which(cmd):
+                cnfg.priv_elev_cmd = cmd
                 print(f"Using {cmd} for privilege elevation")
-                return cmd
+                return
 
         # If no elevation command found
         error("No known privilege elevation command found. Cannot continue.")

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-__version__ = '20250308'                        # CLI option "--version" will print this out.
+__version__ = '20250313'                        # CLI option "--version" will print this out.
 
 import os
 os.environ['PYTHONDONTWRITEBYTECODE'] = '1'     # prevent this script from creating cache files

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -531,13 +531,13 @@ def call_attn_to_pwd_prompt_if_needed():
     main_clr = 'blue'
     alt_clr = 'magenta'
     print()
-    print(fancy_str('  ----------------------------------------  ', main_clr, bold=True))
+    print(fancy_str('  -----------------------------------------  ', main_clr, bold=True))
     print(
         fancy_str('  -- ', main_clr, bold=True) +
-        fancy_str('     PASSWORD REQUIRED TO CONTINUE', alt_clr, bold=True) +
+        fancy_str('   PASSWORD REQUIRED TO CONTINUE   ', alt_clr, bold=True) +
         fancy_str(' --  ', main_clr, bold=True)
     )
-    print(fancy_str('  ----------------------------------------  ', main_clr, bold=True))
+    print(fancy_str('  -----------------------------------------  ', main_clr, bold=True))
     print()
 
 

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -1128,12 +1128,12 @@ pkg_groups_map: Dict[str, List[str]] = {
                             "xset",
                             "zenity"],
 
-    'chimera-based':       ["cairo-dev",
-                            "dbus-dev", 
-                            "clang", "git", "gobject-introspection-dev",
-                            "libayatana-appindicator-dev", "libnotify", "libxkbcommon-dev",
-                            "python3-dev", "py3-pip", "py3-dbus", "py3-tk",
-                            "evdev", "input-utils",
+    'chimera-based':       ["cairo-devel", "clang",
+                            "dbus-devel", 
+                            "git", "gobject-introspection-devel",
+                            "libayatana-appindicator-devel", "libnotify", "libxkbcommon-devel",
+                            "python-dbus", "python-devel", "python-evdev", "python-pip",
+                            "tk",
                             "zenity"],
 
 }

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -2180,7 +2180,7 @@ def install_udev_rules():
 
     # Only write the file if it doesn't exist or its contents are different from current rule
     if rules_file_missing_or_content_differs():
-        command_str             = f'sudo tee {rules_file_path}'
+        command_str             = f'{cnfg.priv_elev_cmd} tee {rules_file_path}'
         try:
             call_attn_to_pwd_prompt_if_needed()
             print(f'Using these "udev" rules for "uinput" device: ')
@@ -2242,7 +2242,7 @@ def create_group(group_name):
                     # Special command to make Fedora Silverblue/uBlue work, or usermod will fail: 
                     # grep -E '^input:' /usr/lib/group | sudo tee -a /etc/group
                     command = (f"grep -E '^{group_name}:' /usr/lib/group | "
-                                "sudo tee -a /etc/group >/dev/null")
+                                f"{cnfg.priv_elev_cmd} tee -a /etc/group >/dev/null")
                     try:
                         subprocess.run(command, shell=True, check=True)
                         print(f"Added '{group_name}' group to system.")
@@ -3968,7 +3968,7 @@ def handle_cli_arguments():
 
     subparser_prep_only         = subparsers.add_parser(
         'prep-only',
-        help='Do only prep steps that require sudo/admin, no install'
+        help='Do only prep steps that require admin privileges, no install'
     )
 
     subparser_uninstall         = subparsers.add_parser(
@@ -4099,7 +4099,7 @@ def main(cnfg: InstallerSettings):
         install_distro_pkgs()
 
     if not cnfg.unprivileged_user:
-        # These things require 'sudo' (admin user)
+        # These things require 'sudo/doas/run0' (admin user)
         # Allow them to be skipped to support non-admin users
         # (An admin user would need to first do the "prep-only" command to support this)
         load_uinput_module()

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -614,6 +614,8 @@ def ask_add_home_local_bin():
         print()
         response = input('The "~/.local/bin" folder is not in PATH. OK to add it? [Y/n]: ') or 'y'
         if response in ['y', 'Y']:
+            # Let's prompt a reboot when we need to add local-bin to the PATH
+            cnfg.should_reboot = True
             # create temp file that will get script to add local bin to path without asking
             with open(fix_path_tmp_path, 'a') as file:
                 file.write('Nothing to see here.')

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -289,7 +289,7 @@ class InstallerSettings:
         for cmd in elevation_cmds:
             if shutil.which(cmd):
                 cnfg.priv_elev_cmd = cmd
-                print(f"Using {cmd} for privilege elevation")
+                print(f"Using the '{cmd}' command for privilege elevation.")
                 return
 
         # If no elevation command found

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -2086,7 +2086,8 @@ def load_uinput_module():
             # If not, create it and add "uinput"
             try:
                 call_attn_to_pwd_prompt_if_needed()
-                command = "echo 'uinput' | sudo tee /etc/modules-load.d/uinput.conf >/dev/null"
+                command = (f"echo 'uinput' | {cnfg.priv_elev_cmd} "
+                            "tee /etc/modules-load.d/uinput.conf >/dev/null")
                 subprocess.run(command, shell=True, check=True)
             except subprocess.CalledProcessError as proc_err:
                 error(f"Failed to create /etc/modules-load.d/uinput.conf:\n\t{proc_err}")
@@ -2102,7 +2103,8 @@ def load_uinput_module():
                     # If "uinput" is not listed, append it
                     try:
                         call_attn_to_pwd_prompt_if_needed()
-                        command = "echo 'uinput' | sudo tee -a /etc/modules >/dev/null"
+                        command = (f"echo 'uinput' | {cnfg.priv_elev_cmd} "
+                                    "tee -a /etc/modules >/dev/null")
                         subprocess.run(command, shell=True, check=True)
                     except subprocess.CalledProcessError as proc_err:
                         error(f"ERROR: Failed to append 'uinput' to /etc/modules:\n\t{proc_err}")

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -1135,7 +1135,6 @@ pkg_groups_map: Dict[str, List[str]] = {
                             "git", "gobject-introspection-devel",
                             "libayatana-appindicator-devel", "libnotify", "libxkbcommon-devel",
                             "pkgconf", "python-dbus", "python-devel", "python-evdev", "python-pip",
-                            "tk",
                             "zenity"],
 
 }

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -1128,11 +1128,11 @@ pkg_groups_map: Dict[str, List[str]] = {
                             "xset",
                             "zenity"],
 
-    'chimera-based':       ["cairo-devel", "clang",
+    'chimera-based':       ["cairo-devel", "clang", "cmake",
                             "dbus-devel", 
                             "git", "gobject-introspection-devel",
                             "libayatana-appindicator-devel", "libnotify", "libxkbcommon-devel",
-                            "python-dbus", "python-devel", "python-evdev", "python-pip",
+                            "pkgconf", "python-dbus", "python-devel", "python-evdev", "python-pip",
                             "tk",
                             "zenity"],
 
@@ -1912,7 +1912,7 @@ class PackageInstallDispatcher:
         #     safe_shutdown(1)
 
         # Install packages with --no-cache to avoid prompts about cache management
-        cmd_lst = [cnfg.priv_elev_cmd, 'apk', 'add', '--no-cache']
+        cmd_lst = [cnfg.priv_elev_cmd, 'apk', 'add', '--no-cache', '--no-interactive']
         native_pkg_installer.install_pkg_list(cmd_lst, cnfg.pkgs_for_distro)
 
 

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-__version__ = '20250227'
+__version__ = '20250313'
 
 # Indicator tray icon menu app for Toshy, using pygobject/gi
 TOSHY_PART      = 'tray'   # CUSTOMIZE TO SPECIFIC TOSHY COMPONENT! (gui, tray, config)

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -607,17 +607,18 @@ def set_item_active_with_retry(menu_item, state=True, max_retries=5):
 
 # -------- MENU ITEMS --------------------------------------------------
 
-services_label_item = Gtk.MenuItem(label=" ---- Services Status ---- ")
-services_label_item.set_sensitive(False)
-menu.append(services_label_item)
+if not is_init_systemd():
+    services_label_item = Gtk.MenuItem(label=" ---- Services Status ---- ")
+    services_label_item.set_sensitive(False)
+    menu.append(services_label_item)
 
-toshy_config_status_item = Gtk.MenuItem(    label="      Config: (?)")
-toshy_config_status_item.set_sensitive(False)
-menu.append(toshy_config_status_item)
+    toshy_config_status_item = Gtk.MenuItem(    label="      Config: (?)")
+    toshy_config_status_item.set_sensitive(False)
+    menu.append(toshy_config_status_item)
 
-session_monitor_status_item = Gtk.MenuItem( label="     SessMon: (?)")
-session_monitor_status_item.set_sensitive(False)
-menu.append(session_monitor_status_item)
+    session_monitor_status_item = Gtk.MenuItem( label="     SessMon: (?)")
+    session_monitor_status_item.set_sensitive(False)
+    menu.append(session_monitor_status_item)
 
 
 def is_service_enabled(service_name):
@@ -685,25 +686,26 @@ def fn_toggle_toshy_svcs_autostart(widget):
     ntfy.send_notification(_ntfy_msg, _ntfy_icon_file)
 
 
-autostart_toshy_svcs_item = Gtk.CheckMenuItem(label="Autostart Toshy Services")
-autostart_toshy_svcs_item.set_active(   toshy_svc_sessmon_unit_enabled and 
-                                        toshy_svc_config_unit_enabled       )
-autostart_toshy_svcs_item.connect("toggled", fn_toggle_toshy_svcs_autostart)
-menu.append(autostart_toshy_svcs_item)
+if not is_init_systemd():
+    autostart_toshy_svcs_item = Gtk.CheckMenuItem(label="Autostart Toshy Services")
+    autostart_toshy_svcs_item.set_active(   toshy_svc_sessmon_unit_enabled and 
+                                            toshy_svc_config_unit_enabled       )
+    autostart_toshy_svcs_item.connect("toggled", fn_toggle_toshy_svcs_autostart)
+    menu.append(autostart_toshy_svcs_item)
 
-separator_above_svcs_item = Gtk.SeparatorMenuItem()
-menu.append(separator_above_svcs_item)  #-------------------------------------#
+    separator_above_svcs_item = Gtk.SeparatorMenuItem()
+    menu.append(separator_above_svcs_item)  #-------------------------------------#
 
-restart_toshy_svcs_item = Gtk.MenuItem(label="Re/Start Toshy Services")
-restart_toshy_svcs_item.connect("activate", fn_restart_toshy_services)
-menu.append(restart_toshy_svcs_item)
+    restart_toshy_svcs_item = Gtk.MenuItem(label="Re/Start Toshy Services")
+    restart_toshy_svcs_item.connect("activate", fn_restart_toshy_services)
+    menu.append(restart_toshy_svcs_item)
 
-quit_toshy_svcs_item = Gtk.MenuItem(label="Stop Toshy Services")
-quit_toshy_svcs_item.connect("activate", fn_stop_toshy_services)
-menu.append(quit_toshy_svcs_item)
+    quit_toshy_svcs_item = Gtk.MenuItem(label="Stop Toshy Services")
+    quit_toshy_svcs_item.connect("activate", fn_stop_toshy_services)
+    menu.append(quit_toshy_svcs_item)
 
-separator_below_svcs_item = Gtk.SeparatorMenuItem()
-menu.append(separator_below_svcs_item)  #-------------------------------------#
+    separator_below_svcs_item = Gtk.SeparatorMenuItem()
+    menu.append(separator_below_svcs_item)  #-------------------------------------#
 
 restart_toshy_script_item = Gtk.MenuItem(label="Re/Start Config-Only")
 restart_toshy_script_item.connect("activate", fn_restart_toshy_config_only)

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -950,13 +950,23 @@ menu.show_all()
 def main():
 
     global loop
+    global DISTRO_ID
     global DESKTOP_ENV
     global DE_MAJ_VER
 
     env_ctxt_getter             = EnvironmentInfo()
     env_info_dct                = env_ctxt_getter.get_env_info()
+    DISTRO_ID                   = str(env_info_dct.get('DISTRO_ID', None)).casefold()
     DESKTOP_ENV                 = str(env_info_dct.get('DESKTOP_ENV', None)).casefold()
     DE_MAJ_VER                  = str(env_info_dct.get('DE_MAJ_VER', None)).casefold()
+
+    # Chimera Linux uses 'dinit' instead of 'systemd', services won't run, so use 'inverse' icon
+    if DISTRO_ID == 'chimera' and not DESKTOP_ENV == 'cosmic':
+        # Use 'global' keyword since we need to change the global values here
+        global icon_file_active
+        global icon_file_grayscale
+        icon_file_active        = icon_file_inverse
+        icon_file_grayscale     = icon_file_inverse
 
     # COSMIC desktop environment messes with tray icon, so use 'grayscale' icon
     if DESKTOP_ENV == 'cosmic':

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -954,6 +954,10 @@ def main():
     global DESKTOP_ENV
     global DE_MAJ_VER
 
+    global icon_file_active
+    global icon_file_inverse
+    global icon_file_grayscale
+
     env_ctxt_getter             = EnvironmentInfo()
     env_info_dct                = env_ctxt_getter.get_env_info()
     DISTRO_ID                   = str(env_info_dct.get('DISTRO_ID', None)).casefold()
@@ -964,17 +968,11 @@ def main():
 
     # COSMIC desktop environment messes with tray icon, so use 'grayscale' icon
     if DESKTOP_ENV == 'cosmic':
-        # Use 'global' keyword since we need to change the global values here
-        global icon_file_active
-        global icon_file_inverse
         icon_file_active        = icon_file_grayscale
         icon_file_inverse       = icon_file_grayscale
 
     # On distros known to not use 'systemd', use 'inverse' icon (except on COSMIC)
     elif not DESKTOP_ENV == 'cosmic' and DISTRO_ID in non_sysd_distros:
-        # Use 'global' keyword since we need to change the global values here
-        global icon_file_active
-        global icon_file_grayscale
         icon_file_active        = icon_file_inverse
         icon_file_grayscale     = icon_file_inverse
 

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -964,17 +964,15 @@ def main():
     DESKTOP_ENV                 = str(env_info_dct.get('DESKTOP_ENV', None)).casefold()
     DE_MAJ_VER                  = str(env_info_dct.get('DE_MAJ_VER', None)).casefold()
 
-    non_sysd_distros = ['chimera', 'void']
-
     # COSMIC desktop environment messes with tray icon, so use 'grayscale' icon
     if DESKTOP_ENV == 'cosmic':
         icon_file_active        = icon_file_grayscale
         icon_file_inverse       = icon_file_grayscale
 
     # On distros known to not use 'systemd', use 'inverse' icon (except on COSMIC)
-    elif not DESKTOP_ENV == 'cosmic' and DISTRO_ID in non_sysd_distros:
-        icon_file_active        = icon_file_inverse
-        icon_file_grayscale     = icon_file_inverse
+    elif not DESKTOP_ENV == 'cosmic' and not is_init_systemd():
+        icon_file_active        = "toshy_app_icon_rainbow_inverse"
+        icon_file_grayscale     = "toshy_app_icon_rainbow_inverse"
 
     if shutil.which('systemctl') and is_init_systemd():
         # help out the config file user service

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -971,8 +971,7 @@ def main():
 
     # On distros known to not use 'systemd', use 'inverse' icon (except on COSMIC)
     elif not DESKTOP_ENV == 'cosmic' and not is_init_systemd():
-        icon_file_active        = "toshy_app_icon_rainbow_inverse"
-        icon_file_grayscale     = "toshy_app_icon_rainbow_inverse"
+        tray_indicator.set_icon_full(icon_file_inverse, "Toshy Tray Icon Inactive")
 
     if shutil.which('systemctl') and is_init_systemd():
         # help out the config file user service

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -889,9 +889,10 @@ open_config_folder_item = Gtk.MenuItem(label="Open Config Folder")
 open_config_folder_item.connect("activate", fn_open_config_folder)
 menu.append(open_config_folder_item)
 
-show_services_log_item = Gtk.MenuItem(label="Show Services Log")
-show_services_log_item.connect("activate", fn_show_services_log)
-menu.append(show_services_log_item)
+if is_init_systemd():
+    show_services_log_item = Gtk.MenuItem(label="Show Services Log")
+    show_services_log_item.connect("activate", fn_show_services_log)
+    menu.append(show_services_log_item)
 
 separator_above_remove_icon_item = Gtk.SeparatorMenuItem()
 menu.append(separator_above_remove_icon_item)  #-------------------------------------#

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -960,13 +960,7 @@ def main():
     DESKTOP_ENV                 = str(env_info_dct.get('DESKTOP_ENV', None)).casefold()
     DE_MAJ_VER                  = str(env_info_dct.get('DE_MAJ_VER', None)).casefold()
 
-    # Chimera Linux uses 'dinit' instead of 'systemd', services won't run, so use 'inverse' icon
-    if DISTRO_ID == 'chimera' and not DESKTOP_ENV == 'cosmic':
-        # Use 'global' keyword since we need to change the global values here
-        global icon_file_active
-        global icon_file_grayscale
-        icon_file_active        = icon_file_inverse
-        icon_file_grayscale     = icon_file_inverse
+    non_sysd_distros = ['chimera', 'void']
 
     # COSMIC desktop environment messes with tray icon, so use 'grayscale' icon
     if DESKTOP_ENV == 'cosmic':
@@ -975,6 +969,14 @@ def main():
         global icon_file_inverse
         icon_file_active        = icon_file_grayscale
         icon_file_inverse       = icon_file_grayscale
+
+    # On distros known to not use 'systemd', use 'inverse' icon (except on COSMIC)
+    elif not DESKTOP_ENV == 'cosmic' and DISTRO_ID in non_sysd_distros:
+        # Use 'global' keyword since we need to change the global values here
+        global icon_file_active
+        global icon_file_grayscale
+        icon_file_active        = icon_file_inverse
+        icon_file_grayscale     = icon_file_inverse
 
     if shutil.which('systemctl') and is_init_systemd():
         # help out the config file user service

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -607,7 +607,7 @@ def set_item_active_with_retry(menu_item, state=True, max_retries=5):
 
 # -------- MENU ITEMS --------------------------------------------------
 
-if not is_init_systemd():
+if is_init_systemd():
     services_label_item = Gtk.MenuItem(label=" ---- Services Status ---- ")
     services_label_item.set_sensitive(False)
     menu.append(services_label_item)
@@ -686,7 +686,7 @@ def fn_toggle_toshy_svcs_autostart(widget):
     ntfy.send_notification(_ntfy_msg, _ntfy_icon_file)
 
 
-if not is_init_systemd():
+if is_init_systemd():
     autostart_toshy_svcs_item = Gtk.CheckMenuItem(label="Autostart Toshy Services")
     autostart_toshy_svcs_item.set_active(   toshy_svc_sessmon_unit_enabled and 
                                             toshy_svc_config_unit_enabled       )


### PR DESCRIPTION
**Description of the Changes:**

- Adds support for alternative privilege elevation commands
- Adds support for a new Linux distro: Chimera Linux

**Reason for Changes:**

Setup script used hard-coded references to `sudo`, but some Linux users want to replace `sudo` with `run0` and some distros use `doas` as a `sudo` replacement. Chimera Linux uses `doas`. The script adaptation allows any of the three commands for the installation steps that require privilege elevation. 

**Related Issue(s) or PR(s):**

Resolves #579 (Chimera Linux support)

**Testing Done:**

Tested on multiple different base distro types (RHEL-type, Debian/Ubuntu-type, Tumbleweed, etc.) to verify the adjustment to working with `doas` or `run0` hasn't caused any problems. No problems observed. 

Tested on Chimera Linux (Plasma 6) to ensure that there are no issues. One user already using these changes on Chimera. 

