### PR TITLE
Standardize use of 'screen_has_focus' variable

### DIFF
--- a/default-toshy-config/toshy_config.py
+++ b/default-toshy-config/toshy_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = '20250309'
+__version__ = '20250315'
 ###############################################################################
 ############################   Welcome to Toshy!   ############################
 ###  
@@ -1539,12 +1539,13 @@ modmap("Cond modmap - Forced Numpad feature",{
     Key.KPENTER:                Key.ENTER,
 }, when = lambda ctx:
     cnfg.forced_numpad and
+    cnfg.screen_has_focus and
     matchProps(not_devn=exclude_kpad_devs_Str)(ctx) and
     matchProps(not_clas=remoteStr)(ctx)
 )
 
 
-modmap("Cond modmap - GTK3 numpad nav keys fix",{
+modmap("Cond modmap - GTK3 numpad nav keys fix", {
     # Make numpad nav keys work correctly in GTK3 apps
     # Key.KP5:                    Key.X,                # GTK3 numpad fix - TEST TO SEE IF WORKING
     # Numpad PgUp/PgDn/Home/End keys
@@ -1563,6 +1564,7 @@ modmap("Cond modmap - GTK3 numpad nav keys fix",{
     Key.KPENTER:                Key.ENTER,
 }, when = lambda ctx:
     not cnfg.forced_numpad and
+    cnfg.screen_has_focus and
     matchProps(numlk=False)(ctx) and
     matchProps(not_devn=exclude_kpad_devs_Str)(ctx) and
     matchProps(not_clas=remoteStr)(ctx)
@@ -1580,6 +1582,7 @@ multipurpose_modmap("Enter2Cmd", {
     Key.ENTER:                  [Key.ENTER, Key.RIGHT_CTRL]     # Enter2Cmd
 }, when = lambda ctx:
     cnfg.Enter2Ent_Cmd and
+    cnfg.screen_has_focus and
     matchProps(not_clas=remoteStr)(ctx)
 )
 
@@ -1587,6 +1590,7 @@ multipurpose_modmap("Caps2Esc - not Chromebook kbd", {
     Key.CAPSLOCK:               [Key.ESC, Key.RIGHT_CTRL]       # Caps2Esc - not Chromebook
 }, when = lambda ctx:
     cnfg.Caps2Esc_Cmd and
+    cnfg.screen_has_focus and
     not isKBtype('Chromebook')(ctx) and
     matchProps(not_clas=remoteStr)(ctx)
 )
@@ -1595,6 +1599,7 @@ multipurpose_modmap("Caps2Esc - Chromebook kbd", {
     Key.LEFT_META:               [Key.ESC, Key.RIGHT_CTRL]       # Caps2Esc - Chromebook
 }, when = lambda ctx:
     cnfg.Caps2Esc_Cmd and
+    cnfg.screen_has_focus and
     isKBtype('Chromebook')(ctx) and
     matchProps(not_clas=remoteStr)(ctx)
 )
@@ -1624,6 +1629,7 @@ modmap("Cond modmap - GUI - Caps2Cmd - not Cbk kdb", {
     Key.CAPSLOCK:               Key.RIGHT_CTRL,                 # Caps2Cmd
 }, when = lambda ctx:
     cnfg.Caps2Cmd and
+    cnfg.screen_has_focus and
     not isKBtype('Chromebook')(ctx) and
     matchProps(not_clas=terms_and_remotes_Str)(ctx)
 )
@@ -1631,6 +1637,7 @@ modmap("Cond modmap - GUI - Caps2Cmd - Cbk kdb", {
     Key.LEFT_META:              Key.RIGHT_CTRL,                 # Caps2Cmd - Chromebook
 }, when = lambda ctx:
     cnfg.Caps2Cmd and
+    cnfg.screen_has_focus and
     isKBtype('Chromebook')(ctx) and
     matchProps(not_clas=terms_and_remotes_Str)(ctx)
 )
@@ -1640,6 +1647,7 @@ modmap("Cond modmap - GUI - IBM kbd - multi_lang OFF", {
     Key.RIGHT_CTRL:             Key.RIGHT_ALT,                  # IBM - Multi-language (Remove)
 }, when = lambda ctx:
     not cnfg.multi_lang and
+    cnfg.screen_has_focus and
     isKBtype('IBM', map='mmap GUI IBM ML-OFF')(ctx) and 
     matchProps(not_clas=terms_and_remotes_Str)(ctx)
 )
@@ -1649,6 +1657,7 @@ modmap("Cond modmap - GUI - IBM kbd", {
     Key.LEFT_CTRL:              Key.LEFT_ALT,                   # IBM
     Key.LEFT_ALT:               Key.RIGHT_CTRL,                 # IBM
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     isKBtype('IBM', map='mmap GUI IBM')(ctx) and
     matchProps(not_clas=terms_and_remotes_Str)(ctx)
 )
@@ -1658,6 +1667,7 @@ modmap("Cond modmap - GUI - Cbk kbd - multi_lang OFF", {
     Key.RIGHT_CTRL:             Key.RIGHT_ALT,                  # Chromebook - Multi-language (Remove)
 }, when = lambda ctx:
     not cnfg.multi_lang and
+    cnfg.screen_has_focus and
     isKBtype('Chromebook', map='mmap GUI Cbk ML-OFF')(ctx) and
     matchProps(not_clas=terms_and_remotes_Str)(ctx)
 )
@@ -1666,6 +1676,7 @@ modmap("Cond modmap - GUI - Cbk kbd", {
     Key.LEFT_CTRL:              Key.LEFT_ALT,                   # Chromebook
     Key.LEFT_ALT:               Key.RIGHT_CTRL,                 # Chromebook
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     isKBtype('Chromebook', map='mmap GUI Cbk')(ctx) and
     matchProps(not_clas=terms_and_remotes_Str)(ctx)
 )
@@ -1677,6 +1688,7 @@ modmap("Cond modmap - GUI - Win kbd - multi_lang OFF", {
     Key.RIGHT_CTRL:             Key.RIGHT_META,                 # WinMac - Multi-language (Remove)
 }, when = lambda ctx:
     not cnfg.multi_lang and
+    cnfg.screen_has_focus and
     isKBtype('Windows', map='mmap GUI Win ML-OFF')(ctx) and
     matchProps(not_clas=terms_and_remotes_Str)(ctx)
 )
@@ -1687,6 +1699,7 @@ modmap("Cond modmap - GUI - Win kbd", {
     Key.LEFT_META:              Key.LEFT_ALT,                   # WinMac
     Key.LEFT_ALT:               Key.RIGHT_CTRL,                 # WinMac
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     isKBtype('Windows', map='mmap GUI Win')(ctx) and
     matchProps(not_clas=terms_and_remotes_Str)(ctx)
 )
@@ -1696,6 +1709,7 @@ modmap("Cond modmap - GUI - Mac kbd - multi_lang OFF", {
     Key.RIGHT_CTRL:             Key.RIGHT_META,                 # Mac - Multi-language (Remove)
 }, when = lambda ctx:
     not cnfg.multi_lang and
+    cnfg.screen_has_focus and
     isKBtype('Apple', map='mmap GUI Apple ML-OFF')(ctx) and
     matchProps(not_clas=terms_and_remotes_Str)(ctx)
 )
@@ -1704,6 +1718,7 @@ modmap("Cond modmap - GUI - Mac kbd", {
     Key.LEFT_CTRL:              Key.LEFT_META,                  # Mac
     Key.LEFT_META:              Key.RIGHT_CTRL,                 # Mac
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     isKBtype('Apple', map='mmap GUI Apple')(ctx) and
     matchProps(not_clas=terms_and_remotes_Str)(ctx)
 )
@@ -1715,6 +1730,7 @@ modmap("Cond modmap - Terms - IBM kbd - multi_lang OFF", {
     Key.RIGHT_ALT:              Key.RIGHT_CTRL,                 # IBM - Multi-language (Remove)
 }, when = lambda ctx:
     not cnfg.multi_lang and
+    cnfg.screen_has_focus and
     isKBtype('IBM', map='mmap terms IBM ML-OFF')(ctx) and
     matchProps(clas=termStr)(ctx)
 )
@@ -1726,6 +1742,7 @@ modmap("Cond modmap - Terms - IBM kbd", {
     # Right Meta does not exist on IBM keyboards
     Key.RIGHT_CTRL:             Key.RIGHT_ALT,                  # IBM
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     isKBtype('IBM', map='mmap terms IBM')(ctx) and
     matchProps(clas=termStr)(ctx)
 )
@@ -1734,6 +1751,7 @@ modmap("Cond modmap - Terms - Cbk kbd - multi_lang OFF", {
     Key.RIGHT_ALT:              Key.RIGHT_CTRL,                 # Chromebook - Multi-language (Remove)
 }, when = lambda ctx:
     not cnfg.multi_lang and
+    cnfg.screen_has_focus and
     isKBtype('Chromebook', map='mmap terms Cbk ML-OFF')(ctx) and
     matchProps(clas=termStr)(ctx)
 )
@@ -1745,6 +1763,7 @@ modmap("Cond modmap - Terms - Cbk kbd", {
     # Right Meta does not exist on chromebooks
     Key.RIGHT_CTRL:             Key.RIGHT_ALT,                  # Chromebook
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     isKBtype('Chromebook', map='mmap terms Cbk')(ctx) and
     matchProps(clas=termStr)(ctx)
 )
@@ -1756,6 +1775,7 @@ modmap("Cond modmap - Terms - Win kbd - multi_lang OFF", {
     Key.RIGHT_CTRL:             Key.LEFT_CTRL,                  # WinMac - Multi-language (Remove)
 }, when = lambda ctx:
     not cnfg.multi_lang and
+    cnfg.screen_has_focus and
     isKBtype('Windows', map='mmap terms Win ML-OFF')(ctx) and
     matchProps(clas=termStr)(ctx)
 )
@@ -1766,6 +1786,7 @@ modmap("Cond modmap - Terms - Win kbd", {
     Key.LEFT_META:              Key.LEFT_ALT,                   # WinMac
     Key.LEFT_ALT:               Key.RIGHT_CTRL,                 # WinMac
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     isKBtype('Windows', map='mmap terms Win')(ctx) and
     matchProps(clas=termStr)(ctx)
 )
@@ -1776,6 +1797,7 @@ modmap("Cond modmap - Terms - Mac kbd - multi_lang OFF", {
     Key.RIGHT_CTRL:             Key.LEFT_CTRL,                  # Mac - Multi-language (Remove)
 }, when = lambda ctx:
     not cnfg.multi_lang and
+    cnfg.screen_has_focus and
     isKBtype('Apple', map='mmap terms Apple ML-OFF')(ctx) and
     matchProps(clas=termStr)(ctx)
 )
@@ -1787,6 +1809,7 @@ modmap("Cond modmap - Terms - Mac kbd", {
     Key.LEFT_META:              Key.RIGHT_CTRL,                 # Mac
     Key.RIGHT_ALT:              Key.RIGHT_ALT,                  # Mac (self-modmap)
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     isKBtype('Apple', map='mmap terms Apple')(ctx) and
     matchProps(clas=termStr)(ctx)
 )
@@ -3113,6 +3136,7 @@ keymap("OptSpecialChars - ABC", {
     C("Shift-Alt-Slash"):       UC(0x00BF),                     # ¿ Inverted Question mark
 
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     cnfg.optspec_layout == 'ABC' and
     matchProps(not_clas=terms_and_remotes_Str)(ctx)
 )
@@ -3263,6 +3287,7 @@ keymap("OptSpecialChars - US", {
     C("Shift-Alt-Slash"):       UC(0x00BF),                     # ¿ Inverted Question mark
 
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     cnfg.optspec_layout == 'US' and
     matchProps(not_clas=terms_and_remotes_Str)(ctx)
 )
@@ -3347,19 +3372,25 @@ keymap("Thunderbird email client", {
     # Enable Cmd+Option+Left/Right for tab navigation
     C("RC-Alt-Left"):           C("C-Page_Up"),                 # Go to prior tab (macOS Thunderbird tab nav shortcut)
     C("RC-Alt-Right"):          C("C-Page_Down"),               # Go to next tab (macOS Thunderbird tab nav shortcut)
-}, when = matchProps(clas="^thunderbird.*$|^org.mozilla.thunderbird$") )
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^thunderbird.*$|^org.mozilla.thunderbird$")(ctx) )
 
 keymap("Angry IP Scanner", {
     C("RC-comma"):              C("Shift-C-P"),                 # Open preferences
     C("RC-i"):                  C("Alt-Enter"),                 # Get info (details)
     C("RC-h"):                  C("C-h"),                       # Go to next live host (override hide window)
     C("Shift-RC-i"):            C("C-i"),                       # Invert selection
-}, when = matchProps(clas="^Angry.*IP.*Scanner$") )
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^Angry.*IP.*Scanner$")(ctx) )
 
 keymap("Transmission bittorrent client", {
     C("RC-i"):                  C("Alt-Enter"),                 # Open properties (Get Info) dialog
     C("RC-comma"):             [C("Alt-e"),C("p")],             # Open preferences (settings) dialog
-}, when = matchProps(clas=transmissionStr) )
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas=transmissionStr)(ctx) )
 
 keymap("JDownloader", {
     # Fixes for tab navigation done here instead of in the main tab nav fix keymaps, 
@@ -3378,15 +3409,21 @@ keymap("JDownloader", {
 
 keymap("Totem video player", {
     C("RC-dot"):                C("C-q"),                       # Stop (quit player, there is no "Stop" function)
-}, when = matchProps(clas="^totem$") )
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^totem$")(ctx) )
 
 keymap("GNOME image viewer", {
     C("RC-i"):                  C("Alt-Enter"),                 # Image properties
-}, when = matchProps(clas="^eog$") )
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^eog$")(ctx) )
 
 keymap("LibreOffice Writer", {
     C("RC-comma"):              C("Alt-F12"),                   # Tools > Options (preferences dialog)
-}, when = matchProps(clas="^libreoffice-writer$") )
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^libreoffice-writer$")(ctx) )
 
 
 
@@ -3409,7 +3446,9 @@ keymap("LibreOffice Writer", {
 keymap("Overrides for Caja - Finder Mods", {
     C("RC-Super-o"):            C("Shift-C-Enter"),             # Open in new tab
     # C("RC-Super-o"):            C("Shift-C-W"),                 # Open in new window
-}, when = matchProps(clas="^caja$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^caja$")(ctx) )
 
 # Keybindings overrides for COSMIC Files
 # (overrides some bindings from general file manager code block below)
@@ -3424,7 +3463,9 @@ keymap("Overrides for COSMIC Files - Finder Mods", {
     # COSMIC uses nonstandard shortcut (Space) for file/folder Properties dialog
     C("RC-i"):                  C("Space"),                     # Get info (properties) [MacOS shortcut]
     C("Alt-Enter"):             C("Space"),                     # Get info (properties) [Linux shortcut]
-}, when = matchProps(clas="^com.system76.CosmicFiles$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^com.system76.CosmicFiles$")(ctx) )
 
 # Keybindings overrides for DDE (Deepin) File Manager
 # (overrides some bindings from general file manager code block below)
@@ -3436,7 +3477,9 @@ keymap("Overrides for DDE File Manager - Finder Mods", {
     C("Shift-RC-Right_Brace"):  C("C-Tab"),                     # Go to next tab
     C("Shift-RC-Left"):         C("C-Shift-Tab"),               # Go to prior tab
     C("Shift-RC-Right"):        C("C-Tab"),                     # Go to next tab
-}, when = matchProps(clas="^dde-file-manager$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^dde-file-manager$")(ctx) )
 
 ##########################  DOLPHIN KEYMAPS - BEGIN  ##########################
 # Keybindings overrides for Dolphin (KDE file manager)
@@ -3447,6 +3490,7 @@ keymap("Overrides for Dolphin - Finder Mods pre-KF6", {
     # (Reference https://planet.kde.org/felix-ernst-2023-10-13-f10-for-accessibility-in-kf6/)
     C("Shift-RC-n"):            iEF2(C("F10"), False),          # Create new folder (F10), toggle Enter to be Enter (pre-KF6!)
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     DESKTOP_ENV == 'kde' and DE_MAJ_VER in ['5', '4', '3'] and
     matchProps(clas="^dolphin$|^org.kde.dolphin$")(ctx)
 )
@@ -3463,9 +3507,9 @@ dlgs_Dolphin_Enter_is_Enter_Str = toRgxStr(dlgs_Dolphin_Enter_is_Enter)
 
 keymap("Overrides for Dolphin dialogs - Finder Mods", {
     C("Enter"):                 C("Enter"),                     # Override Enter to be Enter (never F2) for dialogs
-}, when = matchProps(
-    clas="^dolphin$|^org.kde.dolphin$", 
-    name=dlgs_Dolphin_Enter_is_Enter_Str)
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^dolphin$|^org.kde.dolphin$", name=dlgs_Dolphin_Enter_is_Enter_Str)(ctx)
 )
 
 keymap("Overrides for Dolphin - Finder Mods", {
@@ -3479,7 +3523,9 @@ keymap("Overrides for Dolphin - Finder Mods", {
     C("RC-Super-o"):            C("Shift-C-o"),                 # Open in new window (or new tab, user's choice, see above)
     C("Shift-RC-n"):            iEF2(C("Shift-C-n"), False),    # Create new folder, toggle Enter to be Enter (KF6 and later)
     C("RC-comma"):              C("Shift-C-comma"),             # Open preferences dialog
-}, when = matchProps(clas="^dolphin$|^org.kde.dolphin$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^dolphin$|^org.kde.dolphin$")(ctx) )
 
 # 
 ###########################  DOLPHIN KEYMAPS - END  ###########################
@@ -3490,7 +3536,9 @@ keymap("Overrides for Dolphin - Finder Mods", {
 keymap("Overrides for Pantheon - Finder Mods", {
     C("RC-Super-o"):            C("Shift-Enter"),               # Open folder in new tab
     C("RC-comma"):              None,                           # Disable preferences shortcut since none available
-}, when = matchProps(clas="^io.elementary.files$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^io.elementary.files$")(ctx) )
 
 # Keybindings overrides for Krusader (alternative/old KDE file manager)
 # (overrides some bindings from general file manager code block below)
@@ -3504,13 +3552,17 @@ keymap("Overrides for Krusader - Finder Mods", {
     C("RC-KEY_4"):              None,                           # View as Gallery [Not available, blocked]
     C("RC-Backspace"):         [C("Delete"), sleep(0.5), C("Tab"), sleep(0.5), C("Enter")],    # Delete file/folder (auto-confirm)
     # C("RC-Backspace"):          C("Delete"),                    # Delete file/folder (no auto-confirm)
-}, when = matchProps(clas="^org.kde.krusader$|^krusader$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^org.kde.krusader$|^krusader$")(ctx) )
 
 # Keybindings overrides for Nautilus
 # (overrides some bindings from general file manager code block below)
 keymap("Overrides for Nautilus Create Archive dialog - Finder Mods", {
     C("Enter"):                 C("Enter"),                     # Use Enter as Enter in the Create Archive dialog
-}, when = matchProps(clas="^org.gnome.nautilus$|^nautilus$", name="Create Archive"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^org.gnome.nautilus$|^nautilus$", name="Create Archive")(ctx) )
 
 keymap("Overrides for Nautilus - Finder Mods", {
     # Optional "new window at home folder" in Nautilus
@@ -3523,19 +3575,25 @@ keymap("Overrides for Nautilus - Finder Mods", {
     C("RC-Super-o"):            C("C-Enter"),                   # Open in new tab (disable line above)
     C("RC-comma"):              C("C-comma"),                   # Overrides "Open preferences dialog" shortcut below
     C("RC-F"):                  C("C-F"),                       # Don't toggle Enter key, pass Cmd+F
-}, when = matchProps(clas="^org.gnome.nautilus$|^nautilus$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^org.gnome.nautilus$|^nautilus$")(ctx) )
 
 # Keybindings overrides for Nemo
 # (overrides some bindings from general file manager code block below)
 keymap("Overrides for Nemo - Finder Mods", {
     C("RC-Backspace"):          iEF2(C("Delete"), False),       # Set Enter to Enter for Cmd+Delete confirmation
-}, when = matchProps(clas="^nemo$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^nemo$")(ctx) )
 
 # Keybindings overrides for PCManFM and PCManFM-Qt
 # (overrides some bindings from general file manager code block below)
 keymap("Overrides for PCManFM-Qt - Finder Mods - LXQt desktop", {
     C("Enter"):                 C("Enter"),                     # Use Enter as Enter on the LXQt desktop
-}, when = matchProps(clas="^pcmanfm-qt$", name="^pcmanfm-desktop.*$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^pcmanfm-qt$", name="^pcmanfm-desktop.*$")(ctx) )
 keymap("Overrides for PCManFM-Qt - Finder Mods", {
     C("RC-Backspace"):          C("Delete"),                    # Move to Trash (delete, bypass dialog)
     # Change folder view
@@ -3543,13 +3601,17 @@ keymap("Overrides for PCManFM-Qt - Finder Mods", {
     C("RC-KEY_2"):  [C("Alt-V"), sleep(0.1), C("V"), sleep(0.1), C("D")],   # View as List (Detailed)
     C("RC-KEY_3"):  [C("Alt-V"), sleep(0.1), C("V"), sleep(0.1), C("C")],   # View as List (Compact)
     C("RC-KEY_4"):  [C("Alt-V"), sleep(0.1), C("V"), sleep(0.1), C("T")],   # View as Thumbnails
-}, when = matchProps(clas="^pcmanfm-qt$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^pcmanfm-qt$")(ctx) )
 
 keymap("Overrides for PCManFM - Finder Mods", {
     C("RC-KEY_2"):              C("C-KEY_4"),                   # View as List (Detailed) [Not in PCManFM-Qt]
     C("RC-Backspace"):         [C("Delete"),C("Space")],        # Move to Trash (delete, bypass dialog)
     C("RC-F"):                  C("C-F"),                       # Don't toggle Enter key state, pass Cmd+F (Ctrl+F)
-}, when = matchProps(clas="^pcmanfm$|^pcmanfm-qt$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^pcmanfm$|^pcmanfm-qt$")(ctx) )
 
 keymap("Overrides for Peony-Qt - Finder Mods", {
     C("RC-Comma"):              None,                           # Block Cmd+Comma (doesn't work in Peony)
@@ -3558,7 +3620,9 @@ keymap("Overrides for Peony-Qt - Finder Mods", {
     C("Shift-RC-Right_Brace"):  C("C-Tab"),                     # Go to next tab
     C("Shift-RC-Left"):         C("C-Shift-Tab"),               # Go to prior tab
     C("Shift-RC-Right"):        C("C-Tab"),                     # Go to next tab
-}, when = matchProps(clas="^peony-qt$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^peony-qt$")(ctx) )
 
 # Keybindings overrides for SpaceFM
 # (overrides some bindings from general file manager code block below)
@@ -3566,7 +3630,9 @@ keymap("Overrides for SpaceFM Find Files dialog - Finder Mods", {
     C("Enter"):                 C("Enter"),                     # Use Enter as Enter in the Find dialog
     C("Esc"):                   C("Alt-F4"),                    # Close Find Files dialog with Escape
     C("RC-W"):                  C("Alt-F4"),                    # Close Find Files dialog with Cmd+W
-}, when = matchProps(clas="^SpaceFM$", name="Find Files"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^SpaceFM$", name="Find Files")(ctx) )
 
 keymap("Overrides for SpaceFM - Finder Mods", {
     C("RC-Page_Up"):            C("C-Shift-Tab"),               # Go to prior tab
@@ -3582,7 +3648,9 @@ keymap("Overrides for SpaceFM - Finder Mods", {
     C("RC-comma"):             [C("Alt-V"),C("p")],             # Overrides "Open preferences dialog" shortcut below
     # This shortcut ^^^^^^^^^^^^^^^ is not fully working in SpaceFM. Opens "View" menu but not Preferences.
     # SpaceFM is doing some nasty binding that blocks all shortcuts, including Alt+Tab, while any menu is open.
-}, when = matchProps(clas="^spacefm$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^spacefm$")(ctx) )
 
 # Keybindings overrides for Thunar
 # (overrides some bindings from general file manager code block below)
@@ -3590,7 +3658,9 @@ keymap("Overrides for Thunar - Finder Mods", {
     C("RC-Super-o"):            C("Shift-C-P"),                 # Open in new tab
     C("RC-comma"):             [C("Alt-E"),C("E")],             # Overrides "Open preferences dialog" shortcut below
     C("RC-F"):                  C("C-F"),                       # Don't toggle Enter key, pass Cmd+F (Ctrl+F)
-}, when = matchProps(clas="^thunar$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^thunar$")(ctx) )
 
 # Keybindings overrides for GNOME XDG "Save As" and "Open File" dialogs
 file_open_save_dialogs = [
@@ -3678,7 +3748,9 @@ keymap("General File Managers - Finder Mods", {
     # C("Tab"):               iEF2(C("Tab"), C("Tab"), True, True),       # Set Enter to Enter after using Tab key
     C("Shift-RC-Space"):    iEF2(C("Shift-C-Space"), False),    # Set Enter to Enter for alternate overview shortcut
     C("Shift-RC-Enter"):        C("Enter"),                             # alternative "Enter" key for unusual cases
-}, when = matchProps(clas=filemanagerStr))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas=filemanagerStr)(ctx) )
 
 
 
@@ -3704,23 +3776,31 @@ keymap("Firefox Browsers Overrides", {
     # Block shortcuts that might get confused with Shift+Cmd+[Left/Right]_Brace
     C("Shift-RC-Minus"):        ignore_combo,                       # Ignore alternate zoom out shortcut
     C("Shift-RC-Equal"):        ignore_combo,                       # Ignore alternate zoom in shortcut
-}, when = matchProps(clas=browsers_firefoxStr))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas=browsers_firefoxStr)(ctx) )
 
 # Zotero is a Firefox based research app
 keymap("Zotero", {
     # (override the Shift+Opt+Cmd+I,I diagnostic dialog shortcut in Zotero)
     C("Shift-Alt-RC-i"):        C("Shift-Alt-C-i"),             # Import from clipboard
-}, when = matchProps(clas="^.*Zotero.*$") )
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^.*Zotero.*$")(ctx) )
 
 # Vivaldi is a Chromium based web browser
 keymap("Overrides for Vivaldi browser", {
     C("RC-comma"):              C("C-F12"),                     # Open preferences
-}, when = matchProps(clas="^Vivaldi.*$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^Vivaldi.*$")(ctx) )
 
 # Falkon is a Chromium based web browser
 keymap("Overrides for Falkon browser", {
     C("RC-comma"):              C("Shift-C-comma"),             # Open preferences
-}, when = matchProps(clas="^org.kde.falkon$|^Falkon$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^org.kde.falkon$|^Falkon$")(ctx) )
 
 keymap("Chrome Browsers Overrides", {
     # C("C-comma"):              [C("Alt-e"), C("s"),C("Enter")], # Open preferences
@@ -3736,7 +3816,9 @@ keymap("Chrome Browsers Overrides", {
     C("RC-y"):                  C("C-H"),                       # Browser History
     C("Alt-RC-u"):              C("C-U"),                       # View Page Source
     C("Shift-RC-j"):            C("C-J"),                       # Show Downloads view
-}, when = matchProps(clas=browsers_chromeStr))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas=browsers_chromeStr)(ctx) )
 
 # Keybindings for General Web Browsers
 keymap("General Web Browsers", {
@@ -3764,7 +3846,9 @@ keymap("General Web Browsers", {
     # Use Cmd+Braces keys for tab navigation instead of page navigation 
     # C("C-Left_Brace"):        C("C-Page_Up"),
     # C("C-Right_Brace"):       C("C-Page_Down"),
-}, when = matchProps(clas=browsers_allStr))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas=browsers_allStr)(ctx) )
 
 
 
@@ -3870,7 +3954,9 @@ keymap("Jetbrains", {
     # VCS/Local History
     C("Super-v"):               C("Alt-Grave"),                 # VCS quick popup
     C("Super-c"):               C("C-c"),                       # Sigints - interrupt
-}, when = matchProps(clas="^jetbrains-(?!.*toolbox).*$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^jetbrains-(?!.*toolbox).*$")(ctx) )
 
 keymap("Wordwise - not vscode", {
     # Wordwise remaining - for Everything but VS Code
@@ -3902,6 +3988,7 @@ keymap("Wordwise - not vscode", {
 keymap("VSCodes overrides for Chromebook/IBM - Sublime", {
     C("C-Alt-g"):               C("C-f2"),                      # Chromebook/IBM - Sublime - find_all_under
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     cnfg.ST3_in_VSCode and
     (   isKBtype('Chromebook', map="vscodes ovr cbook - sublime")(ctx) or
         isKBtype('IBM', map="vscodes ovr ibm - sublime")(ctx) ) and
@@ -3910,6 +3997,7 @@ keymap("VSCodes overrides for Chromebook/IBM - Sublime", {
 keymap("VSCodes overrides for not Chromebook/IBM - Sublime", {
     C("Super-C-g"):             C("C-f2"),                      # Default - Sublime - find_all_under
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     cnfg.ST3_in_VSCode and
     not ( isKBtype('Chromebook', map="vscodes ovr not cbook - sublime")(ctx) or 
     isKBtype('IBM', map="vscodes ovr not ibm - sublime")(ctx) ) and 
@@ -3919,6 +4007,7 @@ keymap("VSCodes overrides for Chromebook/IBM", {
     C("Alt-c"):                 C("C-c"),                       #  Chromebook/IBM - Terminal - Sigint
     C("Alt-x"):                 C("C-x"),                       #  Chromebook/IBM - Terminal - Exit nano
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     (   isKBtype('Chromebook', map="vscodes ovr cbook")(ctx) or 
         isKBtype('IBM', map="vscodes ovr ibm")(ctx) ) and
     matchProps(clas=vscodeStr)(ctx)
@@ -3927,6 +4016,7 @@ keymap("VSCodes overrides for not Chromebook/IBM", {
     C("Super-c"):               C("C-c"),                       # Default - Terminal - Sigint
     C("Super-x"):               C("C-x"),                       # Default - Terminal - Exit nano
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     not (   isKBtype('Chromebook', map="vscodes ovr not cbook")(ctx) or
             isKBtype('IBM', map="vscodes ovr not ibm")(ctx) ) and
     matchProps(clas=vscodeStr)(ctx)
@@ -4007,6 +4097,7 @@ keymap("Sublime Text overrides for Chromebook/IBM", {
     C("Alt-Refresh"):           ignore_combo,                   # Chromebook/IBM - cancel find_all_under
     C("Alt-C-g"):               C("Alt-Refresh"),               # Chromebook/IBM - find_all_under
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     (   isKBtype('Chromebook', map="sublime ovr cbook")(ctx) or 
         isKBtype('IBM', map="sublime ovr ibm")(ctx) ) and
     matchProps(clas=sublimeStr)(ctx)
@@ -4017,6 +4108,7 @@ keymap("Sublime Text overrides for not Chromebook/IBM", {
     C("Alt-f3"):                ignore_combo,                   # Default - cancel find_all_under
     C("Super-C-g"):             C("Alt-f3"),                    # Default - find_all_under
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     not (   isKBtype('Chromebook', map="sublime ovr not cbook")(ctx) or 
             isKBtype('IBM', map="sublime ovr not ibm")(ctx) ) and
     matchProps(clas=sublimeStr)(ctx)
@@ -4088,34 +4180,46 @@ keymap("Sublime Text", {
     C("C-Alt-Shift-Key_5"):     C("Alt-Shift-Key_5"),           # set_layout
     # C(""):                    ignore_combo,                   # cancel
     # C(""):                    C(""),                          #
-}, when = matchProps(clas=sublimeStr))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas=sublimeStr)(ctx) )
 
 keymap("Kate Advanced Text Editor", {
     C("RC-Comma"):              C("Shift-C-Comma"),             # Open settings/preferences
     C("RC-g"):                  C("F3"),                        # Find next
     C("Super-g"):               C("C-g"),                       # Go to line
-}, when = matchProps(clas="^org.kde.kate$") )
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^org.kde.kate$")(ctx) )
 
 keymap("Linux Mint xed text editor", {
     C("RC-T"):                  C("C-N"),                       # Open new tab (new file)
-}, when = matchProps(clas="^xed$") )
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^xed$")(ctx) )
 
 keymap("KWrite text editor - Close Document dialog", {
     C("RC-d"):                  C("Alt-d"),                     # [D]iscard file without saving (from Close Document dialog)
     C("RC-s"):                  C("Alt-s"),                     # Save file (from Close Document dialog)
-}, when = matchProps(clas="^kwrite$|^org.kde.Kwrite$", name="^Close Document.*KWrite$") )
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^kwrite$|^org.kde.Kwrite$", name="^Close Document.*KWrite$")(ctx) )
 keymap("KWrite text editor", {
     C("RC-comma"):              C("Shift-C-comma"),             # Open preferences dialog
     C("RC-t"):                  C("C-n"),                       # New tab (new document)
     C("Super-g"):               C("C-g"),                       # Go to line with physical Ctrl+G
     C("RC-g"):                  C("F3"),                        # Find next instance (Cmd+G)
     C("Shift-RC-g"):            C("Shift-F3"),                  # Find previous instance (Shift+Cmd+G)
-}, when = matchProps(clas="^kwrite$|^org.kde.Kwrite$") )
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^kwrite$|^org.kde.Kwrite$")(ctx) )
 
 keymap("GNOME Text Editor", {
     C("RC-Slash"):              None,                           # Block Cmd+Slash from doing "Select All"
     C("RC-Alt-f"):              C("C-h"),                       # Search and replace within the document
-}, when = matchProps(clas="^gnome-text-editor$|^org.gnome.TextEditor$") )
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^gnome-text-editor$|^org.gnome.TextEditor$")(ctx) )
 
 
 ###########################  DIALOG FIXES  ###########################
@@ -4227,14 +4331,18 @@ keymap("Konsole tab switching", {
     # Konsole tab switching in KDE4 (not needed in KDE5)
     C("Shift-RC-Left_Brace"):   C("Shift-Left"),                # Go to prior tab (Left)
     C("Shift-RC-Right_Brace"):  C("Shift-Right"),               # Go to next tab (Right)
-}, when = matchProps(clas="^konsole$|^org.kde.Konsole$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^konsole$|^org.kde.Konsole$")(ctx) )
 
 keymap("Elementary Terminal tab switching", {
     # Ctrl Tab - In App Tab Switching
     C("LC-Tab") :               C("Shift-C-Right"),             # Go to next tab (Right)
     C("Shift-LC-Tab") :         C("Shift-C-Left"),              # Go to prior tab (Left)
     C("LC-Grave") :             C("Shift-C-Left"),              # Go to prior tab (Left)
-}, when = matchProps(clas="^Io.elementary.terminal$|^kitty$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^Io.elementary.terminal$|^kitty$")(ctx) )
 
 
 
@@ -4252,13 +4360,17 @@ keymap("Elementary Terminal tab switching", {
 
 keymap("Alacritty terminal", {
     C("RC-K"):                  C("C-L"),                       # clear log
-}, when = matchProps(clas="^alacritty$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^alacritty$")(ctx) )
 
 
 keymap("COSMIC Terminal overrides", {
     # There are already tab nav fixes in the usual place.
     C("RC-equal"):              C("C-equal"),                   # Increase font size (override general terminals remap)
-}, when = matchProps(clas="^com.system76.CosmicTerm$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^com.system76.CosmicTerm$")(ctx) )
 
 
 keymap("Deepin Terminal overrides", {
@@ -4266,7 +4378,9 @@ keymap("Deepin Terminal overrides", {
     C("RC-j"):                  None,                           # Block Cmd+J from remapping to vertical split (Ctrl+Shift+J) 
     C("RC-minus"):              C("C-minus"),                   # Decrease font size/zoom out 
     C("RC-equal"):              C("C-equal"),                   # Increase font size/zoom in
-}, when = matchProps(clas="^deepin-terminal$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^deepin-terminal$")(ctx) )
 
 keymap("Ghostty terminal overrides", {
     C("RC-Equal"):              C("C-Equal"),                   # Increase font size [override general terminals remap]
@@ -4274,24 +4388,32 @@ keymap("Ghostty terminal overrides", {
     C("RC-Shift-D"):            C("RC-Shift-E"),                # Open down split
     C("RC-Alt-I"):              C("RC-Shift-I"),                # Open inspector
     C("RC-K"):                  C("C-L"),                       # clear log
-}, when = matchProps(clas="^ghostty$|^ghostty-debug$|^com.mitchellh.ghostty$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^ghostty$|^ghostty-debug$|^com.mitchellh.ghostty$")(ctx) )
 
 keymap("Hyper terminal tab switching", {
     C("RC-Equal"):              C("C-Equal"),                   # Increase font size [override general terminals remap]
     C("Shift-LC-Tab"):          C("Shift-C-Tab"),               # Tab nav: Go to prior tab (left) [override general remap]
     C("LC-Tab"):                C("C-Tab"),                     # Tab nav: Go to next tab (right) [override general remap]
-}, when = matchProps(clas="^hyper$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^hyper$")(ctx) )
 
 keymap("Kitty terminal - not tab nav", {
     C("RC-L"):                  C("C-L"),                       # Clear log
     C("RC-K"):                  C("C-L"),                       # Clear log (macOS)
-}, when = matchProps(clas="^kitty$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^kitty$")(ctx) )
 
 keymap("Konsole terminal - not tab nav", {
     C("RC-comma"):              C("Shift-C-comma"),             # Open Preferences dialog
     C("RC-0"):                  C("C-Alt-0"),                   # Reset font size
     C("RC-K"):                  C("Shift-C-K"),                 # Clear Scrollback and Reset
-}, when = matchProps(clas="^Konsole$|^org.kde.Konsole$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^Konsole$|^org.kde.Konsole$")(ctx) )
 
 keymap("Terminology terminal", {
     C("RC-w"):                  C("Shift-C-End"),               # Close focused tab
@@ -4300,7 +4422,9 @@ keymap("Terminology terminal", {
     C("RC-0"):                  C("C-Alt-0"),                   # Reset font size
     C("RC-Minus"):              C("C-Alt-Minus"),               # Decrease font size
     C("RC-Equal"):              C("C-Alt-Equal"),               # Increase font size
-}, when = matchProps(clas="^terminology$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^terminology$")(ctx) )
 
 keymap("Wave terminal", {
     C("RC-t"):                  C("Alt-t"),                     # Open a new tab
@@ -4308,11 +4432,15 @@ keymap("Wave terminal", {
     C("Shift-RC-n"):            C("Shift-Alt-n"),               # Open a new window
     C("RC-w"):                  C("Alt-w"),                     # Close the current block
     C("Shift-RC-w"):            C("Shift-Alt-w"),               # Close the current tab
-}, when = matchProps(clas="^Wave$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^Wave$")(ctx) )
 
 keymap("Xfce4 terminal", {
     C("RC-comma"):      [C("Alt-e"), sleep(0.1), C("e")],       # Open Preferences dialog
-}, when = matchProps(clas="^xfce4-terminal$"))
+}, when = lambda ctx:
+    cnfg.screen_has_focus and
+    matchProps(clas="^xfce4-terminal$")(ctx) )
 
 
 # Overrides to General Terminals shortcuts for specific distros (or are they really just desktop environments?)
@@ -4535,6 +4663,7 @@ keymap("GenGUI overrides: Chromebook/IBM", {
     C("RAlt-Backspace"):        C("Delete"),                        # Chromebook/IBM - Delete
     C("LAlt-Backspace"):        C("C-Backspace"),                   # Chromebook/IBM - Delete Left Word of Cursor
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     (   isKBtype('Chromebook', map="gengui ovr cbook")(ctx) or 
         isKBtype('IBM', map="gengui ovr ibm")(ctx) ) and
     matchProps(not_clas=remoteStr)(ctx)
@@ -4545,6 +4674,7 @@ keymap("GenGUI overrides: not Chromebook", {
     C("Super-Shift-Tab"):      [iEF2NT(),bind,C("Shift-C-Tab")],    # Default not-chromebook
     C("Alt-Backspace"):         C("C-Backspace"),                   # Default not-chromebook
 }, when = lambda ctx:
+    cnfg.screen_has_focus and
     not isKBtype('Chromebook', map="gengui ovr not cbook")(ctx) and
     matchProps(not_clas=remoteStr)(ctx)
 )


### PR DESCRIPTION
The use of the `cnfg.screen_has_focus` variable like this in all modmap and keymap conditional 'when' arguments is not strictly necessary, as long as there is a usage of `matchProps()` in the conditional expression. But having it as a direct variable reference will minimize the time it takes to deactivate each modmap/keymap in the case of a KVM switch app taking focus away from the screen where Toshy is doing its remapping. 

No real difference in behavior should be observed after this change. Many modmaps/keymaps already had the variable reference in their conditional expression. This just standardizes the usage to almost all modmaps and keymaps, except those that should stay active even if screen focus is lost. (Diagnostic shortcuts keymap, for instance.)

Users' custom keymaps that forget to reference the screen focus variable will just be checked by `matchProps()`, normally. It won't be a problem unless there is no call to `matchProps()` at all in the conditional expression, and also no reference to the screen focus variable. In which case the keymap would stay active if the screen lost focus. 
