### PR TITLE
Add support for AerynOS/moss package manager

### DIFF
--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -2245,21 +2245,6 @@ class PackageInstallDispatcher:
     @staticmethod
     def install_on_moss_distro():
         """utility function that gets dispatched for distros that use Moss package manager"""
-
-        # AerynOS doesn't come with /etc/modules-load.d by default
-        # so add it if it doesn't exist
-        modules_dir                 = '/etc/modules-load.d'
-
-        if not os.path.exists(modules_dir):
-            print(f"Creating directory: '{modules_dir}'")
-            try:
-                call_attn_to_pwd_prompt_if_needed()
-                cmd_lst = [cnfg.priv_elev_cmd, 'mkdir', '-p', modules_dir]
-                subprocess.run(cmd_lst, check=True)
-            except subprocess.CalledProcessError as proc_err:
-                error(f"Problem while creating /etc/modules-load.d folder:\n\t{proc_err}")
-                safe_shutdown(1)
-        
         native_pkg_installer.check_for_pkg_mgr_cmd('moss')
         call_attn_to_pwd_prompt_if_needed()
         cmd_lst = [cnfg.priv_elev_cmd, 'moss', 'install', '--yes-all']


### PR DESCRIPTION
**Description of the Changes:**
I followed the guide in the wiki for adding support for a new distro. Most changes are along those lines, however there are a couple oddities to get it working with AerynOS, which hopefully will be OK. If not no worries if you want to reject this.

First is that AerynOS doesn't ship with `/etc/modules-load.d` or `/etc/modules`. However it does support autoloading from `/etc/modules-load.d` just fine when it does exist, so I added a check to create it in `install_on_moss_distro`. I'm not sure if that's the best place, but I wanted to make sure it was created before `setup_uinput_module` was run.

Second, running `python -m venv` is currently broken in AerynOS. They expect to have it fixed in the future, but running `virtualenv` works fine now. So I added a check if it is AerynOS to use `virtualenv` instead.


**Testing Done:**
Tested on multiple virtual machines, and one bare metal install.