### PR TITLE
fix: remove SIGCHLD=SIG_IGN that breaks GLib event loop on newer distros

### DIFF
--- a/toshy_common/process_manager.py
+++ b/toshy_common/process_manager.py
@@ -80,8 +80,6 @@ class ProcessManager:
 
         signal.signal(signal.SIGINT, signal_handler)
         signal.signal(signal.SIGQUIT, signal_handler)
-        # Stop each last child process from hanging on as a "zombie" after it quits.
-        signal.signal(signal.SIGCHLD, signal.SIG_IGN)
 
     def get_pid_from_lockfile(self):
         """


### PR DESCRIPTION
## Problem

Closes #835

After updating to v26.05.0, `toshy-gui` and `toshy-tray` silently fail to open on Fedora 44 (and likely any distro with a newer GLib/GTK4). The process starts and hangs indefinitely with no window or error.

## Root Cause

The `ProcessManager` refactor introduced in v26.05.0 calls `_setup_signal_handlers()` in `__init__`, which runs before `app.run()`. That method set:

```python
signal.signal(signal.SIGCHLD, signal.SIG_IGN)
```

Setting `SIGCHLD = SIG_IGN` before the GLib main loop starts causes GTK4's event loop to freeze completely on newer GLib versions — `do_activate()` is never called, no window is created, and `GLib.timeout_add()` callbacks never fire either.

## Fix

Remove the `SIGCHLD` override. GLib/GTK4 manages child process cleanup internally and does not need Python-level `SIGCHLD` suppression. This fix is safe on older distros as well — all `subprocess.run()` calls in Toshy are blocking (no orphaned children), and GLib handles any processes it spawns itself.

## Verification

Confirmed on Fedora 44, GNOME Wayland, Python 3.14.4, GTK 4.22. Both `toshy-gui` and `toshy-tray` work correctly after this change.