### PR TITLE
Fix Touch Bar Fn key not switching to F-keys while running (T2 MacBooks)

### DIFF
--- a/default-toshy-config/toshy_config.py
+++ b/default-toshy-config/toshy_config.py
@@ -1829,6 +1829,112 @@ def isMultiTap( tap_1_action: 'Callable | None' = None,
 
 
 
+# ──────────────────────────────────────────────────────────────────────────────
+#  Apple Touch Bar: keep the "Fn" key switching to F1-F12 while Toshy runs
+#  (T2 / Touch Bar MacBooks only — no-op on all other hardware).
+#
+#  To remap the internal keyboard the keymapper takes an exclusive evdev grab
+#  (EVIOCGRAB) on it. The kernel `hid_appletb_kbd` driver normally watches the
+#  Fn key (via an input handler attached to that same keyboard device) to switch
+#  the Touch Bar between the media row and the F1-F12 row. An exclusive grab
+#  routes events only to the keymapper and bypasses the driver's handler, so the
+#  Touch Bar stops responding to Fn while Toshy runs (and works again the moment
+#  the services are stopped and the grab is released).
+#
+#  Since the keymapper is now the only process that sees the Fn key, we reproduce
+#  the driver's behavior in userspace by writing the Touch Bar's writable
+#  per-device sysfs `mode` attribute. We mirror the native default (momentary):
+#  show F-keys while Fn is held, restore the previous mode on release. Values:
+#  0 = esc-only, 1 = function keys (F1-F12), 2 = media/special keys.
+#
+#  The `mode` attribute must be group-writable by the `input` group; the Toshy
+#  installer adds a udev rule for that (see `install_udev_rules()` in setup).
+
+import glob as _glob
+
+_APPLETB_MODE_FNKEYS    = '1'   # show F1-F12 row
+_APPLETB_MODE_DEFAULT   = '2'   # media/special keys row (fallback if read fails)
+
+
+def _find_appletb_mode_path():
+    """Return the writable Touch Bar `mode` sysfs path, or None if not present.
+
+    A `mode` attribute is matched only when the HID device is actually bound to
+    the `hid_appletb_kbd` driver (its sysfs name is `hid-appletb-kbd`). This is
+    independent of USB product ID, yet an unrelated HID device that happens to
+    expose a generic `mode` attribute can never be mistaken for an Apple Touch
+    Bar — so this is a safe no-op on all non-Touch-Bar hardware.
+    """
+    for path in _glob.glob('/sys/bus/hid/devices/*/mode'):
+        driver_link = os.path.join(os.path.dirname(path), 'driver')
+        driver_name = os.path.basename(os.path.realpath(driver_link))
+        if driver_name.replace('_', '-') == 'hid-appletb-kbd':
+            return path
+    return None
+
+
+_appletb_mode_path      = _find_appletb_mode_path()
+
+if _appletb_mode_path:
+
+    from evdev import ecodes as _ecodes
+
+    _appletb_saved_mode = _APPLETB_MODE_DEFAULT
+    _appletb_warned     = False
+
+    def _appletb_warn_once(msg):
+        global _appletb_warned
+        if not _appletb_warned:
+            _appletb_warned = True
+            error(f"## touchbar-fn: {msg}")
+
+    def _touchbar_fn_observe(event):
+        """Drive the Touch Bar mode from Fn press/release. Side-effect only;
+        must never raise into the key-event pipeline."""
+        global _appletb_saved_mode
+        try:
+            if event.type != _ecodes.EV_KEY or event.code != _ecodes.KEY_FN:
+                return
+            if event.value == 1:            # Fn pressed: remember mode, show F-keys
+                try:
+                    with open(_appletb_mode_path, 'r') as f:
+                        current = f.read().strip()
+                    if current in ('0', '1', '2'):
+                        _appletb_saved_mode = current
+                except OSError:
+                    pass                    # keep last known saved mode
+                with open(_appletb_mode_path, 'w') as f:
+                    f.write(_APPLETB_MODE_FNKEYS)
+            elif event.value == 0:          # Fn released: restore previous mode
+                with open(_appletb_mode_path, 'w') as f:
+                    f.write(_appletb_saved_mode)
+            # event.value == 2 (auto-repeat) is intentionally ignored
+        except OSError as os_err:
+            _appletb_warn_once(
+                f"could not write '{_appletb_mode_path}' (need 'input' group write "
+                f"access; is the Toshy udev rule installed?): {os_err}")
+        except Exception as unexpected:     # never disturb the key event pipeline
+            _appletb_warn_once(f"unexpected error: {unexpected}")
+
+    # Install the hook by wrapping the input loop's `on_event` reference.
+    # `xwaykeyz/input.py` does `from .transform import on_event` and calls that
+    # module-global by name, so we must patch the name in `xwaykeyz.input`
+    # (patching `xwaykeyz.transform.on_event` would not be seen by the loop).
+    try:
+        import xwaykeyz.input as _xwk_input
+        if not getattr(_xwk_input, '_toshy_touchbar_hooked', False):
+            def _on_event_with_touchbar(event, device, _orig=_xwk_input.on_event):
+                _touchbar_fn_observe(event)
+                return _orig(event, device)
+            _xwk_input.on_event = _on_event_with_touchbar
+            _xwk_input._toshy_touchbar_hooked = True
+            debug(f"## touchbar-fn: Fn->Touch Bar handler active "
+                    f"(mode sysfs: {_appletb_mode_path})")
+    except Exception as hook_err:
+        error(f"## touchbar-fn: failed to install Fn handler: {hook_err}")
+
+
+
 #################################  MODMAPS  ####################################
 ###                                                                          ###
 ###                                                                          ###

--- a/default-toshy-config/toshy_config_barebones.py
+++ b/default-toshy-config/toshy_config_barebones.py
@@ -1116,6 +1116,112 @@ def isMultiTap( tap_1_action: 'Callable | None' = None,
 
 
 
+# ──────────────────────────────────────────────────────────────────────────────
+#  Apple Touch Bar: keep the "Fn" key switching to F1-F12 while Toshy runs
+#  (T2 / Touch Bar MacBooks only — no-op on all other hardware).
+#
+#  To remap the internal keyboard the keymapper takes an exclusive evdev grab
+#  (EVIOCGRAB) on it. The kernel `hid_appletb_kbd` driver normally watches the
+#  Fn key (via an input handler attached to that same keyboard device) to switch
+#  the Touch Bar between the media row and the F1-F12 row. An exclusive grab
+#  routes events only to the keymapper and bypasses the driver's handler, so the
+#  Touch Bar stops responding to Fn while Toshy runs (and works again the moment
+#  the services are stopped and the grab is released).
+#
+#  Since the keymapper is now the only process that sees the Fn key, we reproduce
+#  the driver's behavior in userspace by writing the Touch Bar's writable
+#  per-device sysfs `mode` attribute. We mirror the native default (momentary):
+#  show F-keys while Fn is held, restore the previous mode on release. Values:
+#  0 = esc-only, 1 = function keys (F1-F12), 2 = media/special keys.
+#
+#  The `mode` attribute must be group-writable by the `input` group; the Toshy
+#  installer adds a udev rule for that (see `install_udev_rules()` in setup).
+
+import glob as _glob
+
+_APPLETB_MODE_FNKEYS    = '1'   # show F1-F12 row
+_APPLETB_MODE_DEFAULT   = '2'   # media/special keys row (fallback if read fails)
+
+
+def _find_appletb_mode_path():
+    """Return the writable Touch Bar `mode` sysfs path, or None if not present.
+
+    A `mode` attribute is matched only when the HID device is actually bound to
+    the `hid_appletb_kbd` driver (its sysfs name is `hid-appletb-kbd`). This is
+    independent of USB product ID, yet an unrelated HID device that happens to
+    expose a generic `mode` attribute can never be mistaken for an Apple Touch
+    Bar — so this is a safe no-op on all non-Touch-Bar hardware.
+    """
+    for path in _glob.glob('/sys/bus/hid/devices/*/mode'):
+        driver_link = os.path.join(os.path.dirname(path), 'driver')
+        driver_name = os.path.basename(os.path.realpath(driver_link))
+        if driver_name.replace('_', '-') == 'hid-appletb-kbd':
+            return path
+    return None
+
+
+_appletb_mode_path      = _find_appletb_mode_path()
+
+if _appletb_mode_path:
+
+    from evdev import ecodes as _ecodes
+
+    _appletb_saved_mode = _APPLETB_MODE_DEFAULT
+    _appletb_warned     = False
+
+    def _appletb_warn_once(msg):
+        global _appletb_warned
+        if not _appletb_warned:
+            _appletb_warned = True
+            error(f"## touchbar-fn: {msg}")
+
+    def _touchbar_fn_observe(event):
+        """Drive the Touch Bar mode from Fn press/release. Side-effect only;
+        must never raise into the key-event pipeline."""
+        global _appletb_saved_mode
+        try:
+            if event.type != _ecodes.EV_KEY or event.code != _ecodes.KEY_FN:
+                return
+            if event.value == 1:            # Fn pressed: remember mode, show F-keys
+                try:
+                    with open(_appletb_mode_path, 'r') as f:
+                        current = f.read().strip()
+                    if current in ('0', '1', '2'):
+                        _appletb_saved_mode = current
+                except OSError:
+                    pass                    # keep last known saved mode
+                with open(_appletb_mode_path, 'w') as f:
+                    f.write(_APPLETB_MODE_FNKEYS)
+            elif event.value == 0:          # Fn released: restore previous mode
+                with open(_appletb_mode_path, 'w') as f:
+                    f.write(_appletb_saved_mode)
+            # event.value == 2 (auto-repeat) is intentionally ignored
+        except OSError as os_err:
+            _appletb_warn_once(
+                f"could not write '{_appletb_mode_path}' (need 'input' group write "
+                f"access; is the Toshy udev rule installed?): {os_err}")
+        except Exception as unexpected:     # never disturb the key event pipeline
+            _appletb_warn_once(f"unexpected error: {unexpected}")
+
+    # Install the hook by wrapping the input loop's `on_event` reference.
+    # `xwaykeyz/input.py` does `from .transform import on_event` and calls that
+    # module-global by name, so we must patch the name in `xwaykeyz.input`
+    # (patching `xwaykeyz.transform.on_event` would not be seen by the loop).
+    try:
+        import xwaykeyz.input as _xwk_input
+        if not getattr(_xwk_input, '_toshy_touchbar_hooked', False):
+            def _on_event_with_touchbar(event, device, _orig=_xwk_input.on_event):
+                _touchbar_fn_observe(event)
+                return _orig(event, device)
+            _xwk_input.on_event = _on_event_with_touchbar
+            _xwk_input._toshy_touchbar_hooked = True
+            debug(f"## touchbar-fn: Fn->Touch Bar handler active "
+                    f"(mode sysfs: {_appletb_mode_path})")
+    except Exception as hook_err:
+        error(f"## touchbar-fn: failed to install Fn handler: {hook_err}")
+
+
+
 ###################################################################################################
 ###  SLICE_MARK_START: barebones_user_cfg  ###  EDITS OUTSIDE THESE MARKS WILL BE LOST ON UPGRADE
 

--- a/setup_toshy.py
+++ b/setup_toshy.py
@@ -3286,10 +3286,33 @@ def install_udev_rules():
 
     if setfacl_path is not None:
         acl_rule                = f', RUN+="{setfacl_path} -m g::rw /dev/uinput"'
+
+    # Apple Touch Bar (T2 MacBooks): the keymapper must grab the internal keyboard
+    # to remap it, which bypasses the in-kernel `hid_appletb_kbd` Fn handler that
+    # switches the Touch Bar to the F1-F12 row. The Toshy config reproduces that
+    # behavior by writing the driver's per-device sysfs `mode` attribute, so that
+    # file needs to be writable by the `input` group. udev expands `$devpath` to
+    # the matched HID device, where the `mode` attribute lives. Harmless no-op on
+    # any machine without an Apple Touch Bar (the rule simply never matches).
+    chgrp_path                  = shutil.which('chgrp')
+    chmod_path                  = shutil.which('chmod')
+    touchbar_rule               = ''
+    if chgrp_path is not None and chmod_path is not None:
+        # NOTE: udev exposes the driver as `hid-appletb-kbd` (dashes), not the
+        # module name `hid_appletb_kbd`. The `?` glob matches either spelling so
+        # this keeps working across kernels. `bind` is included so the rule also
+        # fires when the driver attaches at boot (DRIVER is unset on bare `add`).
+        touchbar_rule           = (
+            'ACTION=="add|change|bind", SUBSYSTEM=="hid", DRIVER=="hid?appletb?kbd", '
+            f'RUN+="{chgrp_path} input /sys$devpath/mode", '
+            f'RUN+="{chmod_path} g+w /sys$devpath/mode"\n'
+        )
+
     new_rules_content           = (
         'SUBSYSTEM=="input", GROUP="input", MODE="0660", TAG+="uaccess"\n'
         'KERNEL=="uinput", SUBSYSTEM=="misc", GROUP="input", MODE="0660", ' # No line break here!
         f'TAG+="uaccess"{acl_rule}\n'
+        f'{touchbar_rule}'
     )
 
     def rules_file_missing_or_content_differs():


### PR DESCRIPTION
## Summary

On Touch Bar MacBooks (T2, running the `t2linux` kernel), pressing **Fn** normally switches the Touch Bar from the media/special row to the **F1–F12** row while held. With Toshy running this stops working; `toshy-services-stop` restores it, and starting the services breaks it again. Everything else (the actual remapping) works fine.

This PR restores the native Fn → F-keys Touch Bar behavior while Toshy is running, without giving up remapping of the internal keyboard. It is a no-op on all non-Touch-Bar hardware.

## Root cause

- To remap the internal keyboard, the keymapper takes an **exclusive evdev grab** (`EVIOCGRAB`) on it — here `"Apple Inc. Apple Internal Keyboard / Trackpad"` (`05AC:027C`). This is correct, necessary behavior.
- On these machines the kernel **`hid_appletb_kbd`** driver detects the Fn key to switch the Touch Bar display. It does so via an **input handler attached to that same keyboard device** (it shows up as the `tbkbd` handler on the keyboard in `/proc/bus/input/devices`).
- An exclusive grab delivers events only to the grabbing client and **bypasses every other in-kernel input handler**, so the driver never sees `KEY_FN` and the Touch Bar stops switching. Releasing the grab (stopping Toshy) restores native behavior. This is a fundamental consequence of the grab — the driver cannot "share" a grabbed device, so the keyboard cannot simply be ignored (that would disable remapping).
- The Touch Bar mode is, however, settable from userspace via a **writable per-device sysfs attribute**: `/sys/bus/hid/devices/0003:05AC:8302.*/mode` (`DEVICE_ATTR_RW(mode)` on the Touch Bar Display HID device). Values: `0` = esc-only, `1` = function keys (F1–F12), `2` = media/special. (Note: the same-named *module parameter* under `/sys/module/...` is read-only — only the per-device attribute is writable.)

## Fix

Since the keymapper is now the only process that sees the Fn key once the device is grabbed, reproduce exactly what the kernel driver does, from inside the keymapper:

- **`default-toshy-config/toshy_config.py` and `toshy_config_barebones.py`**
  - Detect the Touch Bar by globbing `/sys/bus/hid/devices/*/mode` and keeping only a device whose `driver` symlink resolves to `hid-appletb-kbd` (dash/underscore normalized). This is independent of USB product ID, and an unrelated HID device that merely exposes a generic `mode` attribute can never be mistaken for a Touch Bar.
  - If found, wrap `xwaykeyz.input.on_event` (patched on the `xwaykeyz.input` module, because `input.py` does `from .transform import on_event` and calls that module-global by name) to observe raw `KEY_FN` events: on press, save the current mode and write `1` (F-keys); on release, restore the saved mode. Auto-repeat is ignored. This mirrors the driver's **momentary** behavior, and the original `on_event` still runs so Fn keeps its normal role.
  - All sysfs reads/writes are wrapped so the handler can never raise into the key-event pipeline; a single warning is logged once if the mode file isn't writable.
  - The block only installs the hook when a Touch Bar is detected — zero per-keystroke overhead on every other machine (just one sysfs glob at config load).

- **`setup_toshy.py` — `install_udev_rules()`**
  - Installs a udev rule granting the `input` group write access to the Touch Bar `mode` attribute:
    ```
    ACTION=="add|change|bind", SUBSYSTEM=="hid", DRIVER=="hid?appletb?kbd", \
      RUN+="<chgrp> input /sys$devpath/mode", RUN+="<chmod> g+w /sys$devpath/mode"
    ```
  - `DRIVER=="hid?appletb?kbd"` uses a `?` glob because udev exposes the driver as `hid-appletb-kbd` (dashes) rather than the module name `hid_appletb_kbd` (underscores); the glob matches either spelling across kernels. `bind` is included so the rule also fires when the driver attaches at boot (`DRIVER` is unset on a bare `add`). The rule never matches on machines without the Touch Bar.

## Behavior preserved when Toshy stops

The change is purely additive. While grabbed, our hook drives the mode; when Toshy stops and the grab is released, the kernel driver's own Fn handler resumes. Only one of the two is ever live, so there is no double-toggling.

## Testing (on a real T2 MacBook Pro with Touch Bar, `hid_appletb_kbd`)

- Detection finds the correct device; rejects unrelated/no-driver HID devices and empty/non-HID systems.
- Handler unit-tested: Fn press → `1`, auto-repeat ignored, release → restores previous mode (verified for both `2`→…→`2` and `0`→…→`0`); unrelated keys leave the Touch Bar untouched.
- udev rule installs, and after `udevadm trigger` the `mode` file becomes `root:input` `-rw-rw-r--`; userspace write/read round-trip succeeds without sudo.
- Live: keymapper grabs the internal keyboard (`event16`); holding Fn shows F1–F12, releasing restores the media row; `toshy-services-stop` returns control to the kernel driver cleanly.

## Risk to other hardware

- **Config:** no hook is installed unless a `hid_appletb_kbd`-backed `mode` attribute exists — non-Touch-Bar machines pay only a one-time sysfs glob at startup.
- **udev rule:** matches only `SUBSYSTEM=="hid", DRIVER=="hid?appletb?kbd"`, so it is inert everywhere else; its only prerequisite (`chgrp`/`chmod`) is satisfied on any normal Linux, and it is omitted if those are missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
