### PR TITLE
feat(prefs): add "Swap Caps Lock & Control" toggle

### DIFF
--- a/default-toshy-config/toshy_config.py
+++ b/default-toshy-config/toshy_config.py
@@ -2354,6 +2354,47 @@ multipurpose_modmap("Left Opt is Sup & Opt - Win kbd", {
 )
 
 
+# [Swap Caps Lock & Control]
+# True swap: physical CapsLock takes over Toshy's Left Control role, and physical Left Control
+# becomes CapsLock. CapsLock must emit whatever Left Control would emit in the same context, so
+# these mirror the default LEFT_CTRL targets below per keyboard type / context:
+#   - GUI  (Mac/Win kbd):  CapsLock -> LEFT_META  (Super, same as default LEFT_CTRL)
+#   - GUI  (Cbk/IBM kbd):  CapsLock -> LEFT_ALT   (same as default LEFT_CTRL)
+#   - Terms (all kbd):     CapsLock -> LEFT_CTRL  (real Control, same as default LEFT_CTRL)
+#   - All:                 LEFT_CTRL -> CapsLock
+# Registered before all other global conditional modmaps so they win first-match precedence in
+# apply_modmap() and claim LEFT_CTRL before the default LEFT_CTRL modmaps can fire. Modmap output
+# is not re-fed, so CapsLock emits its target literally (no further remapping).
+# NOTE: enabling this removes physical Left Control from Toshy's Cmd/Super scheme (by design).
+# Mutually exclusive with the other Caps Lock options via the Preferences GUI / tray menu.
+modmap("Cond modmap - Caps2Ctrl_Swap - GUI - Mac/Win kbd", {
+    Key.CAPSLOCK:               Key.LEFT_META,                 # Caps2Ctrl_Swap (= default LEFT_CTRL)
+    Key.LEFT_CTRL:              Key.CAPSLOCK,                  # Caps2Ctrl_Swap
+}, when = lambda ctx:
+    cnfg.Caps2Ctrl_Swap and
+    cnfg.screen_has_focus and
+    (ctx_kbd_is_apple or ctx_kbd_is_windows) and
+    not ctx_app_is_terminal and not ctx_app_is_remote
+)
+modmap("Cond modmap - Caps2Ctrl_Swap - GUI - Cbk/IBM kbd", {
+    Key.CAPSLOCK:               Key.LEFT_ALT,                  # Caps2Ctrl_Swap (= default LEFT_CTRL)
+    Key.LEFT_CTRL:              Key.CAPSLOCK,                  # Caps2Ctrl_Swap
+}, when = lambda ctx:
+    cnfg.Caps2Ctrl_Swap and
+    cnfg.screen_has_focus and
+    (ctx_kbd_is_chromebook or ctx_kbd_is_ibm) and
+    not ctx_app_is_terminal and not ctx_app_is_remote
+)
+modmap("Cond modmap - Caps2Ctrl_Swap - Terms - all kbd", {
+    Key.CAPSLOCK:               Key.LEFT_CTRL,                 # Caps2Ctrl_Swap (= default LEFT_CTRL)
+    Key.LEFT_CTRL:              Key.CAPSLOCK,                  # Caps2Ctrl_Swap
+}, when = lambda ctx:
+    cnfg.Caps2Ctrl_Swap and
+    cnfg.screen_has_focus and
+    ctx_app_is_terminal
+)
+
+
 # [Global GUI conditional modmaps] Change modifier keys as in xmodmap
 modmap("Cond modmap - GUI - Caps2Cmd - not Cbk kdb", {
     Key.CAPSLOCK:               Key.RIGHT_CTRL,                 # Caps2Cmd

--- a/toshy_common/settings_class.py
+++ b/toshy_common/settings_class.py
@@ -23,6 +23,10 @@ from toshy_common.overlay_context import (
 )
 
 
+# Caps Lock behavior flags that are mutually exclusive: enabling one clears the others
+CAPS_LOCK_EXCLUSIVE_FLAGS = ('Caps2Cmd', 'Caps2Esc_Cmd', 'Caps2Ctrl_Swap')
+
+
 class Settings:
     def __init__(self, config_dir_path: str = '..') -> None:
         self.config_dir_path        = config_dir_path
@@ -57,6 +61,7 @@ class Settings:
         self.multi_lang             = False                     # Default: False
         self.Caps2Cmd               = False                     # Default: False
         self.Caps2Esc_Cmd           = False                     # Default: False
+        self.Caps2Ctrl_Swap         = False                     # Default: False
         self.Enter2Ent_Cmd          = False                     # Default: False
         self.ST3_in_VSCode          = False                     # Default: False
 
@@ -104,6 +109,15 @@ class Settings:
                 new_mask &= ~child          # parent off, child must be off too
 
         self._overlay_mask = new_mask
+
+    def clear_other_caps_flags(self, keep_flag: str):
+        """Enforce mutual exclusivity of the Caps Lock behavior flags.
+
+        Sets every flag in CAPS_LOCK_EXCLUSIVE_FLAGS to False except `keep_flag`.
+        Does not save; callers persist after updating their UI widgets."""
+        for flag in CAPS_LOCK_EXCLUSIVE_FLAGS:
+            if flag != keep_flag:
+                setattr(self, flag, False)
 
     def ensure_database_setup(self):
         # This will create the database file if it doesn't exist yet
@@ -195,6 +209,7 @@ class Settings:
             ('multi_lang',                  str(self.multi_lang)),
             ('Caps2Cmd',                    str(self.Caps2Cmd)),
             ('Caps2Esc_Cmd',                str(self.Caps2Esc_Cmd)),
+            ('Caps2Ctrl_Swap',              str(self.Caps2Ctrl_Swap)),
             ('Enter2Ent_Cmd',               str(self.Enter2Ent_Cmd)),
             ('l_cmd_is_sup_and_cmd',        str(self.l_cmd_is_sup_and_cmd)),
             ('l_opt_is_sup_and_opt',        str(self.l_opt_is_sup_and_opt)),
@@ -250,6 +265,7 @@ class Settings:
                 elif row[0] == 'multi_lang'             : self.multi_lang           = setting_value
                 elif row[0] == 'Caps2Cmd'               : self.Caps2Cmd             = setting_value
                 elif row[0] == 'Caps2Esc_Cmd'           : self.Caps2Esc_Cmd         = setting_value
+                elif row[0] == 'Caps2Ctrl_Swap'         : self.Caps2Ctrl_Swap       = setting_value
                 elif row[0] == 'Enter2Ent_Cmd'          : self.Enter2Ent_Cmd        = setting_value
                 elif row[0] == 'l_cmd_is_sup_and_cmd'   : self.l_cmd_is_sup_and_cmd = setting_value
                 elif row[0] == 'l_opt_is_sup_and_opt'   : self.l_opt_is_sup_and_opt = setting_value
@@ -401,6 +417,7 @@ class Settings:
         multi_lang              = {self.multi_lang}
         Caps2Cmd                = {self.Caps2Cmd}
         Caps2Esc_Cmd            = {self.Caps2Esc_Cmd}
+        Caps2Ctrl_Swap          = {self.Caps2Ctrl_Swap}
         Enter2Ent_Cmd           = {self.Enter2Ent_Cmd}
         l_cmd_is_sup_and_cmd    = {self.l_cmd_is_sup_and_cmd}
         l_opt_is_sup_and_opt    = {self.l_opt_is_sup_and_opt}

--- a/toshy_gui/gui/settings_panel_gtk4.py
+++ b/toshy_gui/gui/settings_panel_gtk4.py
@@ -3,6 +3,7 @@ gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk, GLib
 
 from toshy_common.logger import debug
+from toshy_common.settings_class import CAPS_LOCK_EXCLUSIVE_FLAGS
 
 # Configuration for help button appearance
 HELP_BUTTON_SIZE = 18   # Width and height in pixels - change here to resize all help buttons
@@ -142,6 +143,18 @@ class SettingsPanel(Gtk.Box):
             "Modmap CapsLock key to be:\n• Escape when tapped\n• Command key for hold/combo"
         )
         column.append(caps_esc_control)
+
+        # Swap CapsLock and Control switch
+        caps_ctrl_swap_control = self.create_switch_with_help(
+            "Swap CapsLock and Control",
+            "Caps2Ctrl_Swap",
+            "Swap CapsLock and Control",
+            "Swap the physical CapsLock and Left Control keys:\n"
+            "• CapsLock acts as Left Control\n"
+            "• Left Control acts as CapsLock\n\n"
+            "Note: enabling this removes physical Left Control from Toshy's Cmd/Super scheme."
+        )
+        column.append(caps_ctrl_swap_control)
 
         # Multipurpose Enter switch
         enter_cmd_control = self.create_switch_with_help(
@@ -463,9 +476,20 @@ class SettingsPanel(Gtk.Box):
         new_value = switch.get_active()
         
         debug(f"Switch toggled: {setting_key} = {new_value}")
-        
+
         # Save to settings
         setattr(self.cnfg, setting_key, new_value)
+
+        # Caps Lock options are mutually exclusive: enabling one clears the others
+        if new_value and setting_key in CAPS_LOCK_EXCLUSIVE_FLAGS:
+            self.cnfg.clear_other_caps_flags(setting_key)
+            for flag in CAPS_LOCK_EXCLUSIVE_FLAGS:
+                if flag == setting_key:
+                    continue
+                other_switch = getattr(self, f"{flag}_switch", None)
+                if other_switch is not None and other_switch.get_active():
+                    other_switch.set_active(False)
+
         self.cnfg.save_settings()
             
     def on_optspec_toggled(self, radio):
@@ -557,7 +581,7 @@ class SettingsPanel(Gtk.Box):
         # Update all switches using stored references
         switch_settings = [
             'altgr_on_menu_key', 'multi_lang', 'ST3_in_VSCode', 'Caps2Cmd', 'Caps2Esc_Cmd',
-            'Enter2Ent_Cmd', 'forced_numpad', 'media_arrows_fix',
+            'Caps2Ctrl_Swap', 'Enter2Ent_Cmd', 'forced_numpad', 'media_arrows_fix',
             'l_opt_is_sup_and_opt', 'l_cmd_is_sup_and_cmd'
         ]
         

--- a/toshy_gui/main_tkinter.py
+++ b/toshy_gui/main_tkinter.py
@@ -23,7 +23,7 @@ runtime = initialize_toshy_runtime()
 # Local imports
 from toshy_common import logger
 from toshy_common.logger import *
-from toshy_common.settings_class import Settings
+from toshy_common.settings_class import Settings, CAPS_LOCK_EXCLUSIVE_FLAGS
 from toshy_common.process_manager import ProcessManager
 from toshy_common.service_manager import ServiceManager
 from toshy_common.monitoring import SettingsMonitor, ServiceMonitor
@@ -218,6 +218,19 @@ def save_radio_settings(cnfg: Settings, var: tk.StringVar, key: str):
 
 def save_switch_settings(cnfg: Settings, var: tk.BooleanVar, key: str):
     setattr(cnfg, key, var.get())
+
+    # Caps Lock options are mutually exclusive: enabling one clears the others
+    if var.get() and key in CAPS_LOCK_EXCLUSIVE_FLAGS:
+        cnfg.clear_other_caps_flags(key)
+        caps_vars = {
+            'Caps2Cmd':         Caps2Cmd_switch_var,
+            'Caps2Esc_Cmd':     Caps2Esc_Cmd_switch_var,
+            'Caps2Ctrl_Swap':   Caps2Ctrl_Swap_switch_var,
+        }
+        for flag, flag_var in caps_vars.items():
+            if flag != key and flag_var.get():
+                flag_var.set(False)
+
     cnfg.save_settings()
 
 
@@ -233,6 +246,7 @@ def load_switch_settings(cnfg: Settings):
     ST3_in_VSCode_switch_var.set(       cnfg.ST3_in_VSCode)
     Caps2Cmd_switch_var.set(            cnfg.Caps2Cmd)
     Caps2Esc_Cmd_switch_var.set(        cnfg.Caps2Esc_Cmd)
+    Caps2Ctrl_Swap_switch_var.set(      cnfg.Caps2Ctrl_Swap)
     Enter2Ent_Cmd_switch_var.set(       cnfg.Enter2Ent_Cmd)
     theme_switch_var.set(               cnfg.gui_dark_theme)
     update_theme()
@@ -418,6 +432,25 @@ Caps2Esc_Cmd_switch_label = tk.Label(
     fg=sw_lbl_font_color
 )
 
+Caps2Ctrl_Swap_switch_var  = tk.BooleanVar(value=False)
+Caps2Ctrl_Swap_switch      = ttk.Checkbutton(
+    left_column,
+    text='Swap CapsLock and Control',
+    style='Switch.TCheckbutton',
+    variable=Caps2Ctrl_Swap_switch_var
+)
+
+Caps2Ctrl_Swap_switch_label = tk.Label(
+    left_column,
+    justify=tk.LEFT,
+    text=f'Swap physical CapsLock and Left Control keys:\
+        \n  • CapsLock acts as Left Control\
+        \n  • Left Control acts as CapsLock',
+    font=sw_lbl_font,
+    wraplength=wrap_len,
+    fg=sw_lbl_font_color
+)
+
 Enter2Ent_Cmd_switch_var = tk.BooleanVar(value=False)
 Enter2Enter_Cmd_switch = ttk.Checkbutton(
     left_column,
@@ -447,6 +480,8 @@ if not runtime.barebones_config:
     Caps2Cmd_label.pack(            anchor=tk.W,    padx=sw_lbl_indent,    pady=btn_lbl_pady)
     Caps2Esc_Cmd_switch.pack(       anchor=tk.W,    padx=sw_padx,          pady=btn_pady)
     Caps2Esc_Cmd_switch_label.pack( anchor=tk.W,    padx=sw_lbl_indent,    pady=btn_lbl_pady)
+    Caps2Ctrl_Swap_switch.pack(     anchor=tk.W,    padx=sw_padx,          pady=btn_pady)
+    Caps2Ctrl_Swap_switch_label.pack(anchor=tk.W,   padx=sw_lbl_indent,    pady=btn_lbl_pady)
     Enter2Enter_Cmd_switch.pack(    anchor=tk.W,    padx=sw_padx,          pady=btn_pady)
     Enter2Ent_Cmd_label.pack(       anchor=tk.W,    padx=sw_lbl_indent,    pady=btn_lbl_pady)
 
@@ -634,6 +669,9 @@ Caps2Cmd_switch.config(
 Caps2Esc_Cmd_switch.config(
     command=lambda: save_switch_settings(
         cnfg, Caps2Esc_Cmd_switch_var, 'Caps2Esc_Cmd'))
+Caps2Ctrl_Swap_switch.config(
+    command=lambda: save_switch_settings(
+        cnfg, Caps2Ctrl_Swap_switch_var, 'Caps2Ctrl_Swap'))
 Enter2Enter_Cmd_switch.config(
     command=lambda: save_switch_settings(
         cnfg, Enter2Ent_Cmd_switch_var, 'Enter2Ent_Cmd'))

--- a/toshy_tray.py
+++ b/toshy_tray.py
@@ -57,7 +57,7 @@ import toshy_common.terminal_utils as term_utils
 from toshy_common import logger
 from toshy_common.logger import *
 from toshy_common.env_context import EnvironmentInfo
-from toshy_common.settings_class import Settings
+from toshy_common.settings_class import Settings, CAPS_LOCK_EXCLUSIVE_FLAGS
 from toshy_common.process_manager import ProcessManager
 from toshy_common.service_manager import ServiceManager
 from toshy_common.monitoring import SettingsMonitor, ServiceMonitor
@@ -385,6 +385,7 @@ if not runtime.barebones_config:
         set_item_active_thread_safe(ST3_in_VSCode_item, cnfg.ST3_in_VSCode)
         set_item_active_thread_safe(Caps2Cmd_item, cnfg.Caps2Cmd)
         set_item_active_thread_safe(Caps2Esc_Cmd_item, cnfg.Caps2Esc_Cmd)
+        set_item_active_thread_safe(Caps2Ctrl_Swap_item, cnfg.Caps2Ctrl_Swap)
         set_item_active_thread_safe(Enter2Ent_Cmd_item, cnfg.Enter2Ent_Cmd)
         set_item_active_thread_safe(l_cmd_is_sup_and_cmd_item, cnfg.l_cmd_is_sup_and_cmd)
         set_item_active_thread_safe(l_opt_is_sup_and_opt_item, cnfg.l_opt_is_sup_and_opt)
@@ -397,9 +398,23 @@ if not runtime.barebones_config:
         cnfg.ST3_in_VSCode          = ST3_in_VSCode_item.get_active()
         cnfg.Caps2Cmd               = Caps2Cmd_item.get_active()
         cnfg.Caps2Esc_Cmd           = Caps2Esc_Cmd_item.get_active()
+        cnfg.Caps2Ctrl_Swap         = Caps2Ctrl_Swap_item.get_active()
         cnfg.Enter2Ent_Cmd          = Enter2Ent_Cmd_item.get_active()
         cnfg.l_cmd_is_sup_and_cmd   = l_cmd_is_sup_and_cmd_item.get_active()
         cnfg.l_opt_is_sup_and_opt   = l_opt_is_sup_and_opt_item.get_active()
+
+        # Caps Lock options are mutually exclusive: enabling one clears the others.
+        # The widget that fired the toggle wins; load_prefs_submenu_settings() (queued
+        # below) syncs the cleared menu items back from cnfg.
+        caps_items = {
+            'Caps2Cmd':         Caps2Cmd_item,
+            'Caps2Esc_Cmd':     Caps2Esc_Cmd_item,
+            'Caps2Ctrl_Swap':   Caps2Ctrl_Swap_item,
+        }
+        for flag, item in caps_items.items():
+            if item is widget and item.get_active():
+                cnfg.clear_other_caps_flags(flag)
+                break
 
         cnfg.save_settings()
         GLib.idle_add(load_prefs_submenu_settings)  # Queue the update to run in GTK's main loop
@@ -431,6 +446,11 @@ if not runtime.barebones_config:
     Caps2Esc_Cmd_item.set_active(cnfg.Caps2Esc_Cmd)
     Caps2Esc_Cmd_item.connect('toggled', save_prefs_settings)
     prefs_submenu.append(Caps2Esc_Cmd_item)
+
+    Caps2Ctrl_Swap_item = Gtk.CheckMenuItem(label='Swap CapsLock and Control')
+    Caps2Ctrl_Swap_item.set_active(cnfg.Caps2Ctrl_Swap)
+    Caps2Ctrl_Swap_item.connect('toggled', save_prefs_settings)
+    prefs_submenu.append(Caps2Ctrl_Swap_item)
 
     Enter2Ent_Cmd_item = Gtk.CheckMenuItem(label='Enter is Enter & Cmd')
     Enter2Ent_Cmd_item.set_active(cnfg.Enter2Ent_Cmd)


### PR DESCRIPTION
## Add "Swap Caps Lock & Control" toggle

  True bidirectional swap: CapsLock takes Left Control's role, Left Control becomes CapsLock. CapsLock emits whatever Left Control would in-context.

  | Context | CapsLock emits |
  | --- | --- |
  | GUI Mac/Win kbd | `LEFT_META` |
  | GUI Cbk/IBM kbd | `LEFT_ALT` |
  | Terminals | `LEFT_CTRL` |
  | All | `LEFT_CTRL` → `CAPSLOCK` |

  **Changes:**
  - `toshy_config.py`: 3 conditional modmaps gated on `Caps2Ctrl_Swap`, registered before global modmaps to win first-match precedence in `apply_modmap()`.
  - `settings_class.py`: new `Caps2Ctrl_Swap` flag + `CAPS_LOCK_EXCLUSIVE_FLAGS` / `clear_other_caps_flags()` helper.
  - GTK4 + Tkinter + tray: toggle in each; enabling one clears other two Caps options.

**Removes physical Left Control from Cmd/Super scheme (by design).**
